### PR TITLE
feat(frontend): Add supervisor card and card stack(SCRUM-84)

### DIFF
--- a/Frontend/components/CardStack/CardStack.test.js
+++ b/Frontend/components/CardStack/CardStack.test.js
@@ -1,0 +1,32 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import CardStack from "./CardStack.vue";
+describe('CardStack', () => {
+    it('renders the correct number of cards based on amount prop', () => {
+        const wrapper = mount(CardStack, {
+            props: {
+                amount: 3
+            },
+            slots: {
+                default: '<div data-test="card">Test Card</div>'
+            }
+        })
+
+        const cards = wrapper.findAll('[data-test="card"]')
+        expect(cards.length).toBe(3)
+    })
+
+    it('renders custom content when provided in the slot', () => {
+        const wrapper = mount(CardStack, {
+            props: {
+                amount: 1
+            },
+            slots: {
+                default: '<div data-test="custom-content">Custom Content</div>'
+            }
+        })
+
+        expect(wrapper.find('[data-test="custom-content"]').exists()).toBe(true)
+        expect(wrapper.text()).toContain('Custom Content')
+    })
+})

--- a/Frontend/components/CardStack/CardStack.vue
+++ b/Frontend/components/CardStack/CardStack.vue
@@ -1,0 +1,25 @@
+<script setup>
+const props = defineProps({
+    amount: {
+        type: Number,
+        default: 3,
+    },
+})
+</script>
+
+<template>
+    <div class="stack w-96">
+        <template v-for="index in props.amount" :key="index">
+            <div :style="{ transform: `rotate(${index === 1 ? 0 : (index % 2 === 0 ? -3 : 3)}deg)` }">
+                <slot>
+                    <div
+                        class="h-48 w-48 bg-error text-error-content grid place-content-center rounded-box text-center">
+                        You forgot to add a Card in the "CardStack" Component! <br>
+                        Go buy drinks🍻<br>
+                        <p class="text-xs">(the tag should also not be self-closing)</p>
+                    </div>
+                </slot>
+            </div>
+        </template>
+    </div>
+</template>

--- a/Frontend/components/CardStack/CardStack.vue
+++ b/Frontend/components/CardStack/CardStack.vue
@@ -5,21 +5,31 @@ const props = defineProps({
         default: 3,
     },
 })
+
+function getRotationStyle(index) {
+    if (index === 1) {
+        return 'rotate(0deg)';
+    }
+    return index % 2 === 0 ? 'rotate(-3deg)' : 'rotate(3deg)';
+}
 </script>
 
 <template>
-    <div class="stack w-96">
-        <template v-for="index in props.amount" :key="index">
-            <div :style="{ transform: `rotate(${index === 1 ? 0 : (index % 2 === 0 ? -3 : 3)}deg)` }">
-                <slot>
-                    <div
-                        class="h-48 w-48 bg-error text-error-content grid place-content-center rounded-box text-center">
-                        You forgot to add a Card in the "CardStack" Component! <br>
-                        Go buy drinks🍻<br>
-                        <p class="text-xs">(the tag should also not be self-closing)</p>
-                    </div>
-                </slot>
-            </div>
-        </template>
+    <div class="stack relative w-fit h-fit">
+        <div
+            v-for="index in props.amount"
+            :key="index"
+            :style="{ transform: getRotationStyle(index) }"
+            class="absolute"
+        >
+            <slot>
+                <div
+                    class="h-48 w-48 bg-error text-error-content grid place-content-center rounded-box text-center">
+                    You forgot to add a Card in the "CardStack" Component! <br>
+                    Go buy drinks🍻<br>
+                    <p class="text-xs">(the tag should also not be self-closing)</p>
+                </div>
+            </slot>
+        </div>
     </div>
 </template>

--- a/Frontend/components/SupervisorCard/SupervisorCard.test.js
+++ b/Frontend/components/SupervisorCard/SupervisorCard.test.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import SupervisorCard from './SupervisorCard.vue'
 import CustomTag from '../CustomTag/CustomTag.vue'
 import { library } from '@fortawesome/fontawesome-svg-core'

--- a/Frontend/components/SupervisorCard/SupervisorCard.test.js
+++ b/Frontend/components/SupervisorCard/SupervisorCard.test.js
@@ -11,7 +11,8 @@ library.add(faUserGroup, faHourglass)
 describe('SupervisorCard', () => {
     const defaultProps = {
         image: 'test-image.jpg',
-        name: 'John Doe',
+        fName: 'John',
+        lName: 'Doe',
         tags: ['tag1', 'tag2', 'tag3'],
         similarityScore: 75,
         maxCapacity: 100,
@@ -32,7 +33,8 @@ describe('SupervisorCard', () => {
         })
 
         expect(wrapper.find('img').attributes('src')).toBe(defaultProps.image)
-        expect(wrapper.text()).toContain(defaultProps.name)
+        expect(wrapper.text()).toContain(defaultProps.fName)
+        expect(wrapper.text()).toContain(defaultProps.lName)
 
         // Check tags
         const tags = wrapper.findAllComponents(CustomTag)

--- a/Frontend/components/SupervisorCard/SupervisorCard.test.js
+++ b/Frontend/components/SupervisorCard/SupervisorCard.test.js
@@ -1,7 +1,12 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect, vi } from 'vitest'
-import { nextTick } from 'vue'
 import SupervisorCard from './SupervisorCard.vue'
+import CustomTag from '../CustomTag/CustomTag.vue'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faUserGroup, faHourglass } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+
+library.add(faUserGroup, faHourglass)
 
 describe('SupervisorCard', () => {
     const defaultProps = {
@@ -13,17 +18,36 @@ describe('SupervisorCard', () => {
         currentCapacity: 50,
     }
 
+    const globalComponents = {
+        CustomTag,
+        FontAwesomeIcon
+    }
+
     it('renders correctly with required props', () => {
         const wrapper = mount(SupervisorCard, {
-            props: defaultProps
+            props: defaultProps,
+            global: {
+                components: globalComponents
+            }
         })
 
         expect(wrapper.find('img').attributes('src')).toBe(defaultProps.image)
         expect(wrapper.text()).toContain(defaultProps.name)
-        expect(wrapper.text()).toContain('75 %') // similarity score
-        expect(wrapper.text()).toContain('50/100') // capacity
-    })
 
+        // Check tags
+        const tags = wrapper.findAllComponents(CustomTag)
+        expect(tags).toHaveLength(6) // 3 regular tags + similarity score + capacity + pending
+
+        // Check scores and capacity
+        const scoreTag = wrapper.findAllComponents(CustomTag)
+            .find(tag => tag.props('text') === '75%')
+        expect(scoreTag).toBeTruthy()
+
+        const capacityTag = wrapper.findAllComponents(CustomTag)
+            .find(tag => tag.props('text') === '50/100 ')
+        expect(capacityTag).toBeTruthy()
+        expect(capacityTag.props('rightIcon')).toBe('user-group')
+    })
 
     it('displays optional description when provided', () => {
         const description = 'This is a test description'
@@ -31,6 +55,9 @@ describe('SupervisorCard', () => {
             props: {
                 ...defaultProps,
                 description
+            },
+            global: {
+                components: globalComponents
             }
         })
 
@@ -42,9 +69,32 @@ describe('SupervisorCard', () => {
             props: {
                 ...defaultProps,
                 pendingAmount: 5
+            },
+            global: {
+                components: globalComponents
             }
         })
 
-        expect(wrapper.text()).toContain('5')
+        const pendingTag = wrapper.findAllComponents(CustomTag)
+            .find(tag => tag.props('text') === '5 ')
+        expect(pendingTag).toBeTruthy()
+        expect(pendingTag.props('rightIcon')).toBe('hourglass')
+    })
+
+    it('limits the number of displayed tags according to maxTagAmount', () => {
+        const wrapper = mount(SupervisorCard, {
+            props: {
+                ...defaultProps,
+                tags: ['tag1', 'tag2', 'tag3', 'tag4', 'tag5'],
+                maxTagAmount: 3
+            },
+            global: {
+                components: globalComponents
+            }
+        })
+
+        const regularTags = wrapper.findAllComponents(CustomTag)
+            .filter(tag => !tag.props('rightIcon') && !tag.props('text').includes('%'))
+        expect(regularTags).toHaveLength(3)
     })
 })

--- a/Frontend/components/SupervisorCard/SupervisorCard.test.js
+++ b/Frontend/components/SupervisorCard/SupervisorCard.test.js
@@ -1,0 +1,50 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import { nextTick } from 'vue'
+import SupervisorCard from './SupervisorCard.vue'
+
+describe('SupervisorCard', () => {
+    const defaultProps = {
+        image: 'test-image.jpg',
+        name: 'John Doe',
+        tags: ['tag1', 'tag2', 'tag3'],
+        similarityScore: 75,
+        maxCapacity: 100,
+        currentCapacity: 50,
+    }
+
+    it('renders correctly with required props', () => {
+        const wrapper = mount(SupervisorCard, {
+            props: defaultProps
+        })
+
+        expect(wrapper.find('img').attributes('src')).toBe(defaultProps.image)
+        expect(wrapper.text()).toContain(defaultProps.name)
+        expect(wrapper.text()).toContain('75 %') // similarity score
+        expect(wrapper.text()).toContain('50/100') // capacity
+    })
+
+
+    it('displays optional description when provided', () => {
+        const description = 'This is a test description'
+        const wrapper = mount(SupervisorCard, {
+            props: {
+                ...defaultProps,
+                description
+            }
+        })
+
+        expect(wrapper.text()).toContain(description)
+    })
+
+    it('displays pending amount badge when provided', () => {
+        const wrapper = mount(SupervisorCard, {
+            props: {
+                ...defaultProps,
+                pendingAmount: 5
+            }
+        })
+
+        expect(wrapper.text()).toContain('5')
+    })
+})

--- a/Frontend/components/SupervisorCard/SupervisorCard.vue
+++ b/Frontend/components/SupervisorCard/SupervisorCard.vue
@@ -1,16 +1,27 @@
 <script setup>
 const props = defineProps({
+    // TODO: revise if we need size as a prop
+    // size: {
+    //     type: String,
+    //     default: 'md',
+    //     required: false,
+    //     validator: (value) => ['xs', 'sm', 'md', 'lg', 'xl', ].includes(value),
+    // },
     image: {
         type: String,
-        default: '',
+        required: true,
     },
     name: {
         type: String,
-        default: '',
+        required: true,
     },
     tags: {
         type: Array,
         default: () => [],
+    },
+    maxTagAmount: {
+        type: Number,
+        default: 4,
     },
     description: {
         type: String,
@@ -19,20 +30,21 @@ const props = defineProps({
     similarityScore: {
         type: Number,
         default: 0,
+        required: true,
     },
     maxCapacity: {
         type: Number,
-        default: 0,
+        required: true,
     },
     currentCapacity: {
         type: Number,
-        default: 0,
+        required:  true
     },
     pendingAmount: {
         type: Number,
         default: 0,
     },
-    dragging: {
+    draggingEnabled: {
         type: Boolean,
         default: false,
     },
@@ -46,13 +58,65 @@ const props = defineProps({
     },
 })
 
+const limitedTags = computed(() => props.tags.slice(0, props.maxTagAmount))
+
 const emit = defineEmits(['swipeLeft', 'swipeRight'])
 
+const handleSwipeLeft = (event) => {
+    event.preventDefault()
+    emit('swipeLeft', event)
+}
+const handleSwipeRight = (event) => {
+    event.preventDefault()
+    emit('swipeRight', event)
+}
 
 </script>
 
 <template>
+<!--    TODO: revise if we need size as a prop-->
+    <div class="card w-96 bg-base-100 card-{{ props.size || 'md' }} shadow-lg">
+        <div class="card-body">
+            <h2 class="card-title font-bold">
+                <div class="mask mask-squircle">
+                    <img class="size-12 rounded-box" :src="props.image"/>
+                </div>{{ props.name }}
+            </h2>
 
+            <p
+                class="text-base-content/50 text-xs line-clamp-4 leading-tight"
+               :class="{ 'h-15': description.trim().length > 0 }"
+            >
+                {{ description }}
+            </p>
+            <!--                TODO: All badges will be replaced with the custom tag component-->
+            <div>
+                <span v-for="tag in limitedTags" class="text-base-content/50 badge badge-lg badge-gray badge-outline mx-0.5 my-0.5">{{ tag }}</span>
+            </div>
+            <div class="card-actions w-full flex justify-between">
+<!--                similarity score badge-->
+                <div class="badge badge-sm badge-gray badge-outline mx-0.5 my-0.5">
+                    <span class="text-base-content/50 ">{{ props.similarityScore }} % </span>
+                </div>
+                <div>
+    <!--                capacity badge-->
+                    <div class="badge badge-sm badge-gray badge-outline mx-0.5 my-0.5">
+                        <span class="text-base-content/50 ">{{ props.currentCapacity }}/{{ props.maxCapacity }} </span>
+                        <svg class="fill-base-content/50 w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" >
+                            <path d="M680-360q-42 0-71-29t-29-71q0-42 29-71t71-29q42 0 71 29t29 71q0 42-29 71t-71 29ZM520-160q-17 0-28.5-11.5T480-200v-16q0-24 12.5-44.5T528-290q36-15 74.5-22.5T680-320q39 0 77.5 7.5T832-290q23 9 35.5 29.5T880-216v16q0 17-11.5 28.5T840-160H520ZM400-480q-66 0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 66-47 113t-113 47ZM80-272q0-34 17-62.5t47-43.5q60-30 124.5-46T400-440q35 0 70 6t70 14l-68 68q-25 25-48.5 51T400-240v39q0 12 4.5 22.5T419-160H160q-33 0-56.5-23.5T80-240v-32Z"/>
+                        </svg>
+                    </div>
+    <!--                pending badge-->
+                    <div class="badge badge-sm badge-gray badge-outline mx-0.5 my-0.5">
+                        <span class="text-base-content/50 ">{{ props.pendingAmount }}</span>
+                        <svg class="fill-base-content/50 w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" >
+                            <path d="M320-160h320v-120q0-66-47-113t-113-47q-66 0-113 47t-47 113v120Zm160-360q66 0 113-47t47-113v-120H320v120q0 66 47 113t113 47ZM200-80q-17 0-28.5-11.5T160-120q0-17 11.5-28.5T200-160h40v-120q0-61 28.5-114.5T348-480q-51-32-79.5-85.5T240-680v-120h-40q-17 0-28.5-11.5T160-840q0-17 11.5-28.5T200-880h560q17 0 28.5 11.5T800-840q0 17-11.5 28.5T760-800h-40v120q0 61-28.5 114.5T612-480q51 32 79.5 85.5T720-280v120h40q17 0 28.5 11.5T800-120q0 17-11.5 28.5T760-80H200Z"/>
+                        </svg>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </template>
 
 <style scoped>

--- a/Frontend/components/SupervisorCard/SupervisorCard.vue
+++ b/Frontend/components/SupervisorCard/SupervisorCard.vue
@@ -2,7 +2,6 @@
 import { computed } from 'vue'
 
 const props = defineProps({
-    // TODO: revise if we need size as a prop
     size: {
         type: String,
         default: 'md',
@@ -46,18 +45,6 @@ const props = defineProps({
         type: Number,
         default: 0,
     },
-    draggingEnabled: {
-        type: Boolean,
-        default: false,
-    },
-    iconSwipeLeft: {
-        type: String,
-        default: 'trash',
-    },
-    iconSwipeRight: {
-        type: String,
-        default: 'check',
-    },
 })
 
 const limitedTags = computed(() => props.tags.slice(0, props.maxTagAmount))
@@ -77,17 +64,6 @@ const imageSizeClasses = computed(() => ({
     'size-14': props.size === 'lg',
     'size-16': props.size === 'xl',
 }))
-
-const emit = defineEmits(['swipeLeft', 'swipeRight'])
-
-const handleSwipeLeft = (event) => {
-    event.preventDefault()
-    emit('swipeLeft', event)
-}
-const handleSwipeRight = (event) => {
-    event.preventDefault()
-    emit('swipeRight', event)
-}
 
 </script>
 

--- a/Frontend/components/SupervisorCard/SupervisorCard.vue
+++ b/Frontend/components/SupervisorCard/SupervisorCard.vue
@@ -13,6 +13,7 @@ const props = defineProps({
         type: String,
         required: true,
     },
+    // TODO: change name to fname and lname for the fallback image
     name: {
         type: String,
         required: true,
@@ -79,7 +80,7 @@ const imageSizeClasses = computed(() => ({
                     <img
                         class="rounded-box"
                         :class="imageSizeClasses"
-                        :src="props.image"
+                        :src="props.image || getPlaceholderImage(props.name)"
                         alt="Profile Picture of {{ props.name }}"
                     />
                 </div>{{ props.name }}
@@ -92,7 +93,7 @@ const imageSizeClasses = computed(() => ({
                 {{ description }}
             </p>
             <div>
-                <CustomTag v-for="tag in limitedTags" :text=tag size="xl" variant="outline"/>
+                <CustomTag v-for="tag in limitedTags" :key=tag :text=tag size="xl" variant="outline"/>
             </div>
             <div class="card-actions w-full flex justify-between">
                 <CustomTag :text="props.similarityScore + '%'" size="xs" variant="clear" color="base-content/50"/>

--- a/Frontend/components/SupervisorCard/SupervisorCard.vue
+++ b/Frontend/components/SupervisorCard/SupervisorCard.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from 'vue'
+import CustomTag from "../CustomTag/CustomTag.vue";
 
 const props = defineProps({
     size: {
@@ -90,30 +91,26 @@ const imageSizeClasses = computed(() => ({
             >
                 {{ description }}
             </p>
-            <!--                TODO: All badges will be replaced with the custom tag component-->
             <div>
-                <span v-for="tag in limitedTags" class="text-base-content/50 badge badge-lg badge-gray badge-outline mx-0.5 my-0.5">{{ tag }}</span>
+                <CustomTag v-for="tag in limitedTags" :text=tag size="xl" variant="outline"/>
             </div>
             <div class="card-actions w-full flex justify-between">
-<!--                similarity score badge-->
-                <div class="badge badge-sm badge-gray badge-outline mx-0.5 my-0.5">
-                    <span class="text-base-content/50 ">{{ props.similarityScore }} % </span>
-                </div>
+                <CustomTag :text="props.similarityScore + '%'" size="xs" variant="clear" color="base-content/50"/>
                 <div>
-    <!--                capacity badge-->
-                    <div class="badge badge-sm badge-gray badge-outline mx-0.5 my-0.5">
-                        <span class="text-base-content/50 ">{{ props.currentCapacity }}/{{ props.maxCapacity }} </span>
-                        <svg class="fill-base-content/50 w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" >
-                            <path d="M680-360q-42 0-71-29t-29-71q0-42 29-71t71-29q42 0 71 29t29 71q0 42-29 71t-71 29ZM520-160q-17 0-28.5-11.5T480-200v-16q0-24 12.5-44.5T528-290q36-15 74.5-22.5T680-320q39 0 77.5 7.5T832-290q23 9 35.5 29.5T880-216v16q0 17-11.5 28.5T840-160H520ZM400-480q-66 0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 66-47 113t-113 47ZM80-272q0-34 17-62.5t47-43.5q60-30 124.5-46T400-440q35 0 70 6t70 14l-68 68q-25 25-48.5 51T400-240v39q0 12 4.5 22.5T419-160H160q-33 0-56.5-23.5T80-240v-32Z"/>
-                        </svg>
-                    </div>
-    <!--                pending badge-->
-                    <div class="badge badge-sm badge-gray badge-outline mx-0.5 my-0.5">
-                        <span class="text-base-content/50 ">{{ props.pendingAmount }}</span>
-                        <svg class="fill-base-content/50 w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960" >
-                            <path d="M320-160h320v-120q0-66-47-113t-113-47q-66 0-113 47t-47 113v120Zm160-360q66 0 113-47t47-113v-120H320v120q0 66 47 113t113 47ZM200-80q-17 0-28.5-11.5T160-120q0-17 11.5-28.5T200-160h40v-120q0-61 28.5-114.5T348-480q-51-32-79.5-85.5T240-680v-120h-40q-17 0-28.5-11.5T160-840q0-17 11.5-28.5T200-880h560q17 0 28.5 11.5T800-840q0 17-11.5 28.5T760-800h-40v120q0 61-28.5 114.5T612-480q51 32 79.5 85.5T720-280v120h40q17 0 28.5 11.5T800-120q0 17-11.5 28.5T760-80H200Z"/>
-                        </svg>
-                    </div>
+                    <CustomTag
+                        :text="props.currentCapacity + '/' + props.maxCapacity + ' '"
+                        right-icon="user-group"
+                        size="xs"
+                        variant="clear"
+                        color="base-content/50"
+                    />
+                    <CustomTag
+                        :text="props.pendingAmount + ' '"
+                        right-icon="hourglass"
+                        size="xs"
+                        variant="clear"
+                        color="base-content/50"
+                    />
                 </div>
             </div>
         </div>

--- a/Frontend/components/SupervisorCard/SupervisorCard.vue
+++ b/Frontend/components/SupervisorCard/SupervisorCard.vue
@@ -13,8 +13,11 @@ const props = defineProps({
         type: String,
         required: true,
     },
-    // TODO: change name to fname and lname for the fallback image
-    name: {
+    fName: {
+        type: String,
+        required: true,
+    },
+    lName: {
         type: String,
         required: true,
     },
@@ -79,14 +82,14 @@ const imageSizeClasses = computed(() => ({
                     <img
                         class="rounded-box"
                         :class="imageSizeClasses"
-                        :src="props.image"
-                        alt="Profile Picture of {{ props.name }}"
+                        :src="props.image || getPlaceholderImage(props.fName, props.lName)"
+                        alt="Profile Picture of {{ props.fName }} {{ props.lName }}"
                     >
-                </div>{{ props.name }}
+                </div>{{ props.fName }} {{ props.lName }}
             </h2>
 
             <p
-                class="text-base-content/50 text-xs line-clamp-4 leading-tight"
+                class="text-base-content/75 text-xs line-clamp-4 leading-tight"
                :class="{ 'h-15': props.description.trim().length > 0 }"
             >
                 {{ description }}

--- a/Frontend/components/SupervisorCard/SupervisorCard.vue
+++ b/Frontend/components/SupervisorCard/SupervisorCard.vue
@@ -3,12 +3,12 @@ import { computed } from 'vue'
 
 const props = defineProps({
     // TODO: revise if we need size as a prop
-    // size: {
-    //     type: String,
-    //     default: 'md',
-    //     required: false,
-    //     validator: (value) => ['xs', 'sm', 'md', 'lg', 'xl', ].includes(value),
-    // },
+    size: {
+        type: String,
+        default: 'md',
+        required: false,
+        validator: (value) => ['xs', 'sm', 'md', 'lg', 'xl', ].includes(value),
+    },
     image: {
         type: String,
         required: true,
@@ -62,6 +62,22 @@ const props = defineProps({
 
 const limitedTags = computed(() => props.tags.slice(0, props.maxTagAmount))
 
+const cardSizeClasses = computed(() => ({
+    'w-72 card-xs': props.size === 'xs',
+    'w-80 card-sm': props.size === 'sm',
+    'w-96 card-md': props.size === 'md',
+    'w-[28rem] card-lg': props.size === 'lg',
+    'w-[32rem] card-xl': props.size === 'xl',
+}))
+
+const imageSizeClasses = computed(() => ({
+    'size-8': props.size === 'xs',
+    'size-10': props.size === 'sm',
+    'size-12': props.size === 'md',
+    'size-14': props.size === 'lg',
+    'size-16': props.size === 'xl',
+}))
+
 const emit = defineEmits(['swipeLeft', 'swipeRight'])
 
 const handleSwipeLeft = (event) => {
@@ -76,12 +92,19 @@ const handleSwipeRight = (event) => {
 </script>
 
 <template>
-<!--    TODO: revise if we need size as a prop-->
-    <div class="card w-96 bg-base-100 card-{{ props.size || 'md' }} shadow-lg">
+    <div
+        class="card bg-base-100 shadow-lg"
+        :class="cardSizeClasses"
+    >
         <div class="card-body">
             <h2 class="card-title font-bold">
                 <div class="mask mask-squircle">
-                    <img class="size-12 rounded-box" :src="props.image"/>
+                    <img
+                        class="rounded-box"
+                        :class="imageSizeClasses"
+                        :src="props.image"
+                        alt="Profile Picture of {{ props.name }}"
+                    />
                 </div>{{ props.name }}
             </h2>
 

--- a/Frontend/components/SupervisorCard/SupervisorCard.vue
+++ b/Frontend/components/SupervisorCard/SupervisorCard.vue
@@ -32,7 +32,6 @@ const props = defineProps({
     },
     similarityScore: {
         type: Number,
-        default: 0,
         required: true,
     },
     maxCapacity: {
@@ -80,9 +79,9 @@ const imageSizeClasses = computed(() => ({
                     <img
                         class="rounded-box"
                         :class="imageSizeClasses"
-                        :src="props.image || getPlaceholderImage(props.name)"
+                        :src="props.image"
                         alt="Profile Picture of {{ props.name }}"
-                    />
+                    >
                 </div>{{ props.name }}
             </h2>
 

--- a/Frontend/components/SupervisorCard/SupervisorCard.vue
+++ b/Frontend/components/SupervisorCard/SupervisorCard.vue
@@ -1,0 +1,60 @@
+<script setup>
+const props = defineProps({
+    image: {
+        type: String,
+        default: '',
+    },
+    name: {
+        type: String,
+        default: '',
+    },
+    tags: {
+        type: Array,
+        default: () => [],
+    },
+    description: {
+        type: String,
+        default: '',
+    },
+    similarityScore: {
+        type: Number,
+        default: 0,
+    },
+    maxCapacity: {
+        type: Number,
+        default: 0,
+    },
+    currentCapacity: {
+        type: Number,
+        default: 0,
+    },
+    pendingAmount: {
+        type: Number,
+        default: 0,
+    },
+    dragging: {
+        type: Boolean,
+        default: false,
+    },
+    iconSwipeLeft: {
+        type: String,
+        default: 'trash',
+    },
+    iconSwipeRight: {
+        type: String,
+        default: 'check',
+    },
+})
+
+const emit = defineEmits(['swipeLeft', 'swipeRight'])
+
+
+</script>
+
+<template>
+
+</template>
+
+<style scoped>
+
+</style>

--- a/Frontend/components/SupervisorCard/SupervisorCard.vue
+++ b/Frontend/components/SupervisorCard/SupervisorCard.vue
@@ -1,4 +1,6 @@
 <script setup>
+import { computed } from 'vue'
+
 const props = defineProps({
     // TODO: revise if we need size as a prop
     // size: {

--- a/Frontend/components/SupervisorCard/SupervisorCard.vue
+++ b/Frontend/components/SupervisorCard/SupervisorCard.vue
@@ -86,7 +86,7 @@ const imageSizeClasses = computed(() => ({
 
             <p
                 class="text-base-content/50 text-xs line-clamp-4 leading-tight"
-               :class="{ 'h-15': description.trim().length > 0 }"
+               :class="{ 'h-15': props.description.trim().length > 0 }"
             >
                 {{ description }}
             </p>

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -8,6 +8,8 @@
       "hasInstallScript": true,
       "dependencies": {
         "@clerk/nuxt": "^1.5.9",
+        "@dicebear/collection": "^9.2.2",
+        "@dicebear/core": "^9.2.2",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/vue-fontawesome": "^3.0.8",
@@ -1875,6 +1877,422 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dicebear/adventurer": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/adventurer/-/adventurer-9.2.2.tgz",
+      "integrity": "sha512-WjBXCP9EXbUul2zC3BS2/R3/4diw1uh/lU4jTEnujK1mhqwIwanFboIMzQsasNNL/xf+m3OHN7MUNJfHZ1fLZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/adventurer-neutral": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/adventurer-neutral/-/adventurer-neutral-9.2.2.tgz",
+      "integrity": "sha512-XVAjhUWjav6luTZ7txz8zVJU/H0DiUy4uU1Z7IO5MDO6kWvum+If1+0OUgEWYZwM+RDI7rt2CgVP910DyZGd1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/avataaars": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/avataaars/-/avataaars-9.2.2.tgz",
+      "integrity": "sha512-WqJPQEt0OhBybTpI0TqU1uD1pSk9M2+VPIwvBye/dXo46b+0jHGpftmxjQwk6tX8z0+mRko8pwV5n+cWht1/+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/avataaars-neutral": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/avataaars-neutral/-/avataaars-neutral-9.2.2.tgz",
+      "integrity": "sha512-pRj16P27dFDBI3LtdiHUDwIXIGndHAbZf5AxaMkn6/+0X93mVQ/btVJDXyW0G96WCsyC88wKAWr6/KJotPxU6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-ears": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-ears/-/big-ears-9.2.2.tgz",
+      "integrity": "sha512-hz4UXdPq4qqZpu0YVvlqM4RDFhk5i0WgPcuwj/MOLlgTjuj63uHUhCQSk6ZiW1DQOs12qpwUBMGWVHxBRBas9g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-ears-neutral": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-ears-neutral/-/big-ears-neutral-9.2.2.tgz",
+      "integrity": "sha512-IPHt8fi3dv9cyfBJBZ4s8T+PhFCrQvOCf91iRHBT3iOLNPdyZpI5GNLmGiV0XMAvIDP5NvA5+f6wdoBLhYhbDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-smile": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-smile/-/big-smile-9.2.2.tgz",
+      "integrity": "sha512-D4td0GL8or1nTNnXvZqkEXlzyqzGPWs3znOnm1HIohtFTeIwXm72Ob2lNDsaQJSJvXmVlwaQQ0CCTvyCl8Stjw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/bottts": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/bottts/-/bottts-9.2.2.tgz",
+      "integrity": "sha512-wugFkzw8JNWV1nftq/Wp/vmQsLAXDxrMtRK3AoMODuUpSVoP3EHRUfKS043xggOsQFvoj0HZ7kadmhn0AMLf5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/bottts-neutral": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/bottts-neutral/-/bottts-neutral-9.2.2.tgz",
+      "integrity": "sha512-lSgpqmSJtlnyxVuUgNdBwyzuA0O9xa5zRJtz7x2KyWbicXir5iYdX0MVMCkp1EDvlcxm9rGJsclktugOyakTlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/collection": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/collection/-/collection-9.2.2.tgz",
+      "integrity": "sha512-vZAmXhPWCK3sf8Fj9/QflFC6XOLroJOT5K1HdnzHaPboEvffUQideGCrrEamnJtlH0iF0ZDXh8gqmwy2fu+yHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dicebear/adventurer": "9.2.2",
+        "@dicebear/adventurer-neutral": "9.2.2",
+        "@dicebear/avataaars": "9.2.2",
+        "@dicebear/avataaars-neutral": "9.2.2",
+        "@dicebear/big-ears": "9.2.2",
+        "@dicebear/big-ears-neutral": "9.2.2",
+        "@dicebear/big-smile": "9.2.2",
+        "@dicebear/bottts": "9.2.2",
+        "@dicebear/bottts-neutral": "9.2.2",
+        "@dicebear/croodles": "9.2.2",
+        "@dicebear/croodles-neutral": "9.2.2",
+        "@dicebear/dylan": "9.2.2",
+        "@dicebear/fun-emoji": "9.2.2",
+        "@dicebear/glass": "9.2.2",
+        "@dicebear/icons": "9.2.2",
+        "@dicebear/identicon": "9.2.2",
+        "@dicebear/initials": "9.2.2",
+        "@dicebear/lorelei": "9.2.2",
+        "@dicebear/lorelei-neutral": "9.2.2",
+        "@dicebear/micah": "9.2.2",
+        "@dicebear/miniavs": "9.2.2",
+        "@dicebear/notionists": "9.2.2",
+        "@dicebear/notionists-neutral": "9.2.2",
+        "@dicebear/open-peeps": "9.2.2",
+        "@dicebear/personas": "9.2.2",
+        "@dicebear/pixel-art": "9.2.2",
+        "@dicebear/pixel-art-neutral": "9.2.2",
+        "@dicebear/rings": "9.2.2",
+        "@dicebear/shapes": "9.2.2",
+        "@dicebear/thumbs": "9.2.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/core": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/core/-/core-9.2.2.tgz",
+      "integrity": "sha512-ROhgHG249dPtcXgBHcqPEsDeAPRPRD/9d+tZCjLYyueO+cXDlIA8dUlxpwIVcOuZFvCyW6RJtqo8BhNAi16pIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@dicebear/croodles": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/croodles/-/croodles-9.2.2.tgz",
+      "integrity": "sha512-OzvAXQWsOgMwL3Sl+lBxCubqSOWoBJpC78c4TKnNTS21rR63TtXUyVdLLzgKVN4YHRnvMgtPf8F/W9YAgIDK4w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/croodles-neutral": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/croodles-neutral/-/croodles-neutral-9.2.2.tgz",
+      "integrity": "sha512-/4mNirxoQ+z1kHXnpDRbJ1JV1ZgXogeTeNp0MaFYxocCgHfJ7ckNM23EE1I7akoo9pqPxrKlaeNzGAjKHdS9vA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/dylan": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/dylan/-/dylan-9.2.2.tgz",
+      "integrity": "sha512-s7e3XliC1YXP+Wykj+j5kwdOWFRXFzYHYk/PB4oZ1F3sJandXiG0HS4chaNu4EoP0yZgKyFMUVTGZx+o6tMaYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/fun-emoji": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/fun-emoji/-/fun-emoji-9.2.2.tgz",
+      "integrity": "sha512-M+rYTpB3lfwz18f+/i+ggNwNWUoEj58SJqXJ1wr7Jh/4E5uL+NmJg9JGwYNaVtGbCFrKAjSaILNUWGQSFgMfog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/glass": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/glass/-/glass-9.2.2.tgz",
+      "integrity": "sha512-imCMxcg+XScHYtQq2MUv1lCzhQSCUglMlPSezKEpXhTxgbgUpmGlSGVkOfmX5EEc7SQowKkF1W/1gNk6CXvBaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/icons": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/icons/-/icons-9.2.2.tgz",
+      "integrity": "sha512-Tqq2OVCdS7J02DNw58xwlgLGl40sWEckbqXT3qRvIF63FfVq+wQZBGuhuiyAURcSgvsc3h2oQeYFi9iXh7HTOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/identicon": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/identicon/-/identicon-9.2.2.tgz",
+      "integrity": "sha512-POVKFulIrcuZf3rdAgxYaSm2XUg/TJg3tg9zq9150reEGPpzWR7ijyJ03dzAADPzS3DExfdYVT9+z3JKwwJnTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/initials": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/initials/-/initials-9.2.2.tgz",
+      "integrity": "sha512-/xNnsEmsstWjmF77htAOuwOMhFlP6eBVXgcgFlTl/CCH/Oc6H7t0vwX1he8KLQBBzjGpvJcvIAn4Wh9rE4D5/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/lorelei": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/lorelei/-/lorelei-9.2.2.tgz",
+      "integrity": "sha512-koXqVr/vcWUPo00VP5H6Czsit+uF1tmwd2NK7Q/e34/9Sd1f4QLLxHjjBNm/iNjCI1+UNTOvZ2Qqu0N5eo7Flw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/lorelei-neutral": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/lorelei-neutral/-/lorelei-neutral-9.2.2.tgz",
+      "integrity": "sha512-Eys9Os6nt2Xll7Mvu66CfRR2YggTopWcmFcRZ9pPdohS96kT0MsLI2iTcfZXQ51K8hvT3IbwoGc86W8n0cDxAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/micah": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/micah/-/micah-9.2.2.tgz",
+      "integrity": "sha512-NCajcJV5yw8uMKiACp694w1T/UyYme2CUEzyTzWHgWnQ+drAuCcH8gpAoLWd67viNdQB/MTpNlaelUgTjmI4AQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/miniavs": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/miniavs/-/miniavs-9.2.2.tgz",
+      "integrity": "sha512-vvkWXttdw+KHF3j+9qcUFzK+P0nbNnImGjvN48wwkPIh2h08WWFq0MnoOls4IHwUJC4GXBjWtiyVoCxz6hhtOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/notionists": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/notionists/-/notionists-9.2.2.tgz",
+      "integrity": "sha512-Z9orRaHoj7Y9Ap4wEu8XOrFACsG1KbbBQUPV1R50uh6AHwsyNrm4cS84ICoGLvxgLNHHOae3YCjd8aMu2z19zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/notionists-neutral": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/notionists-neutral/-/notionists-neutral-9.2.2.tgz",
+      "integrity": "sha512-AhOzk+lz6kB4uxGun8AJhV+W1nttnMlxmxd+5KbQ/txCIziYIaeD3il44wsAGegEpGFvAZyMYtR/jjfHcem3TA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/open-peeps": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/open-peeps/-/open-peeps-9.2.2.tgz",
+      "integrity": "sha512-6PeQDHYyjvKrGSl/gP+RE5dSYAQGKpcGnM65HorgyTIugZK7STo0W4hvEycedupZ3MCCEH8x/XyiChKM2sHXog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/personas": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/personas/-/personas-9.2.2.tgz",
+      "integrity": "sha512-705+ObNLC0w1fcgE/Utav+8bqO+Esu53TXegpX5j7trGEoIMf2bThqJGHuhknZ3+T2az3Wr89cGyOGlI0KLzLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/pixel-art": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/pixel-art/-/pixel-art-9.2.2.tgz",
+      "integrity": "sha512-BvbFdrpzQl04+Y9UsWP63YGug+ENGC7GMG88qbEFWxb/IqRavGa4H3D0T4Zl2PSLiw7f2Ctv98bsCQZ1PtCznQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/pixel-art-neutral": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/pixel-art-neutral/-/pixel-art-neutral-9.2.2.tgz",
+      "integrity": "sha512-CdUY77H6Aj7dKLW3hdkv7tu0XQJArUjaWoXihQxlhl3oVYplWaoyu9omYy5pl8HTqs8YgVTGljjMXYoFuK0JUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/rings": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/rings/-/rings-9.2.2.tgz",
+      "integrity": "sha512-eD1J1k364Arny+UlvGrk12HP/XGG6WxPSm4BarFqdJGSV45XOZlwqoi7FlcMr9r9yvE/nGL8OizbwMYusEEdjw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/shapes": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/shapes/-/shapes-9.2.2.tgz",
+      "integrity": "sha512-e741NNWBa7fg0BjomxXa0fFPME2XCIR0FA+VHdq9AD2taTGHEPsg5x1QJhCRdK6ww85yeu3V3ucpZXdSrHVw5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/thumbs": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/thumbs/-/thumbs-9.2.2.tgz",
+      "integrity": "sha512-FkPLDNu7n5kThLSk7lR/0cz/NkUqgGdZGfLZv6fLkGNGtv6W+e2vZaO7HCXVwIgJ+II+kImN41zVIZ6Jlll7pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@clerk/nuxt": "^1.5.9",
+    "@dicebear/collection": "^9.2.2",
+    "@dicebear/core": "^9.2.2",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/vue-fontawesome": "^3.0.8",

--- a/Frontend/plugins/fontawesome.js
+++ b/Frontend/plugins/fontawesome.js
@@ -9,6 +9,7 @@ import {
   faHourglass,
   faUserGroup
 } from '@fortawesome/free-solid-svg-icons'
+import {defineNuxtPlugin} from "nuxt/app";
 
 library.add(faArrowLeft, faUser, faSearch, faEnvelope, faXmark, faHourglass, faUserGroup)
 

--- a/Frontend/plugins/fontawesome.js
+++ b/Frontend/plugins/fontawesome.js
@@ -1,16 +1,17 @@
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import {
   faArrowLeft,
   faUser,
   faSearch,
   faEnvelope,
   faXmark,
-} from "@fortawesome/free-solid-svg-icons";
-import { defineNuxtPlugin } from "nuxt/app";
+  faHourglass,
+  faUserGroup
+} from '@fortawesome/free-solid-svg-icons'
 
-library.add(faArrowLeft, faUser, faSearch, faEnvelope, faXmark);
+library.add(faArrowLeft, faUser, faSearch, faEnvelope, faXmark, faHourglass, faUserGroup)
 
 export default defineNuxtPlugin((nuxtApp) => {
-  nuxtApp.vueApp.component("FontAwesomeIcon", FontAwesomeIcon);
-});
+  nuxtApp.vueApp.component('FontAwesomeIcon', FontAwesomeIcon)
+})

--- a/Frontend/utils/uiHelpers.ts
+++ b/Frontend/utils/uiHelpers.ts
@@ -1,0 +1,19 @@
+import {createAvatar} from "@dicebear/core";
+import {initials} from "@dicebear/collection";
+
+export const getPlaceholderImage = (fName: string, lName: string) :string => {
+    if (!fName || !lName || fName.length < 1 || lName.length < 1) {
+        return createAvatar(initials, {
+            seed: "",
+            backgroundType: ["gradientLinear","solid"]
+        }).toDataUri()
+    }
+    let inits = "";
+    inits += fName[0]
+    inits += lName[0]
+
+    return createAvatar(initials, {
+        seed: inits,
+        backgroundType: ["gradientLinear","solid"]
+    }).toDataUri()
+}

--- a/Frontend/utils/uiHelpers.ts
+++ b/Frontend/utils/uiHelpers.ts
@@ -14,6 +14,6 @@ export const getPlaceholderImage = (fName: string, lName: string) :string => {
 
     return createAvatar(initials, {
         seed: inits,
-        backgroundType: ["gradientLinear","solid"]
+        backgroundType: ["gradientLinear","solid"],
     }).toDataUri()
 }


### PR DESCRIPTION
This PR adds a card and a card stack component. 

**Card:**
- The card takes these props: `size, image, name, tags, maxTagAmount, description, similarityScore, maxCapacity, currentCapacity, pendingAmount`
- The swipe action did not get implemented, as we will create a seperate swipeWrapper component. 

**CardStack:**
- Displays a specific amount of cards over each other in a messy stack
- amount can be specified as prop and defaults to 3


![image](https://github.com/user-attachments/assets/4e2c6525-5794-47ed-ae06-1d256502b801)
![image](https://github.com/user-attachments/assets/4c76116c-d016-4372-b1fe-eff31a200612)

You can test the components by pasting this in the index.vue and playing around with the props:

```
      <CardStack :amount="8">
          <SupervisorCard
              size="lg"
              :tags="['tag1', 'tag2', 'tag3']"
              current-capacity=65
              max-capacity=24
              similarity-score=1
              name="John Doe"
              image="https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.webp"
              description="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
          />
      </CardStack>
```