### PR TITLE
feat(frontend): add StatusBar component (SCRUM-99)

### DIFF
--- a/Frontend/components/StatusBar/StatusBar.test.ts
+++ b/Frontend/components/StatusBar/StatusBar.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import StatusBar from './StatusBar.vue'
+
+const mockFontAwesomeIcon = {
+    name: 'FontAwesomeIcon',
+    template: '<span><slot /></span>'
+}
+
+describe('StatusBar', () => {
+    const createWrapper = (props = {}) => {
+        return mount(StatusBar, {
+            props,
+            global: {
+                components: {
+                    FontAwesomeIcon: mockFontAwesomeIcon
+                }
+            }
+        })
+    }
+
+    it('renders three steps', () => {
+        const wrapper = createWrapper()
+        const steps = wrapper.findAll('li.step')
+        expect(steps).toHaveLength(3)
+    })
+
+    it('correctly applies step-primary class based on current step', () => {
+        const wrapper = createWrapper({ step: 2 })
+        const steps = wrapper.findAll('li.step')
+
+        // First two steps should be primary, last step should not
+        expect(steps[0].classes()).toContain('step-primary')
+        expect(steps[1].classes()).toContain('step-primary')
+        expect(steps[2].classes()).not.toContain('step-primary')
+    })
+
+    it('applies small text class when smallText prop is true', () => {
+        const wrapper = createWrapper({ smallText: true })
+        const steps = wrapper.findAll('li.step')
+
+        steps.forEach(step => {
+            expect(step.classes()).toContain('text-sm')
+        })
+    })
+
+    it('does not apply small text class when smallText prop is false', () => {
+        const wrapper = createWrapper({ smallText: false })
+        const steps = wrapper.findAll('li.step')
+
+        steps.forEach(step => {
+            expect(step.classes()).not.toContain('text-sm')
+        })
+    })
+
+    it('renders with default props', () => {
+        const wrapper = createWrapper()
+        expect(wrapper.props('step')).toBe(1)
+        expect(wrapper.props('smallText')).toBe(true)
+    })
+
+    it('handles step 3 correctly', () => {
+        const wrapper = createWrapper({ step: 3 })
+        const steps = wrapper.findAll('li.step')
+
+        expect(steps[0].classes()).toContain('step-primary')
+        expect(steps[1].classes()).toContain('step-primary')
+        expect(steps[2].classes()).toContain('step-primary')
+    })
+})

--- a/Frontend/components/StatusBar/StatusBar.vue
+++ b/Frontend/components/StatusBar/StatusBar.vue
@@ -1,0 +1,46 @@
+<script setup>
+    import {FontAwesomeIcon} from "@fortawesome/vue-fontawesome";
+
+    const props = defineProps({
+        step: {
+            type: Number,
+            default: 1,
+        },
+        smallText: {
+            type: Boolean,
+            default: true,
+        },
+    })
+</script>
+
+<template>
+    <ul class="steps w-full">
+        <li
+            class="step text-base-content font-bold"
+            :class="{'step-primary': props.step >= 1, 'text-sm': props.smallText}"
+        >
+            <span class="step-icon" >
+                <FontAwesomeIcon icon="arrow-right-to-bracket"/>
+            </span>
+            Onboarding
+        </li>
+        <li
+            class="step text-base-content font-bold"
+            :class="{'step-primary': props.step >= 2, 'text-sm': props.smallText}"
+        >
+            <span class="step-icon" >
+                <FontAwesomeIcon icon="message"/>
+            </span>
+            Matching
+        </li>
+        <li
+            class="step text-base-content font-bold"
+            :class="{'step-primary': props.step === 3, 'text-sm': props.smallText}"
+        >
+            <span class="step-icon" >
+                <FontAwesomeIcon icon="user-group"/>
+            </span>
+            Confirmed
+        </li>
+    </ul>
+</template>

--- a/Frontend/plugins/fontawesome.js
+++ b/Frontend/plugins/fontawesome.js
@@ -10,10 +10,28 @@ import {
   faUserGroup,
   faMoon,
   faSun,
+  faHandshakeSimple,
+  faMessage,
+  faArrowRightToBracket,
+  faCheck
 } from '@fortawesome/free-solid-svg-icons'
 import {defineNuxtPlugin} from "nuxt/app";
 
-library.add(faArrowLeft, faUser, faSearch, faEnvelope, faXmark, faHourglass, faUserGroup, faMoon, faSun)
+library.add(
+    faArrowLeft,
+    faUser,
+    faSearch,
+    faEnvelope,
+    faXmark,
+    faHourglass,
+    faUserGroup,
+    faArrowRightToBracket,
+    faMessage,
+    faHandshakeSimple,
+    faCheck,
+    faMoon,
+    faSun
+)
 
 export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.component('FontAwesomeIcon', FontAwesomeIcon)


### PR DESCRIPTION
The status bar has icons instead of numbers, @FelixTeutsch approved this


for testing paste this in your index vue
```vue
<template>
  <div class="flex flex-col gap-4">
      <StatusBar :step=1 />
      <StatusBar :step=2 />
      <StatusBar :step=3 />
  </div>
</template>

<script setup>
import StatusBar from "../components/StatusBar/StatusBar.vue";
</script>
```