### PR TITLE
feat(backend): add more more supervisor information within the Match …

### DIFF
--- a/backend/OpenAPI.json
+++ b/backend/OpenAPI.json
@@ -1471,7 +1471,7 @@
           "supervisorId": {
             "type": "string",
             "description": "The unique identifier of the supervisor in this match",
-            "example": "5f8d0d55b54764421b7156f2"
+            "example": "15d2a5bc-c547-444d-91fb-b1c498ada33c"
           },
           "compatibilityScore": {
             "type": "number",

--- a/backend/OpenAPI.json
+++ b/backend/OpenAPI.json
@@ -1468,15 +1468,10 @@
       "Match": {
         "type": "object",
         "properties": {
-          "studentId": {
-            "type": "string",
-            "description": "The unique identifier of the student in this match",
-            "example": "15d2a5bc-c547-444d-91fb-b1c498ada33c"
-          },
           "supervisorId": {
             "type": "string",
             "description": "The unique identifier of the supervisor in this match",
-            "example": "15d2a5bc-c547-444d-91fb-b1c498ada33c"
+            "example": "5f8d0d55b54764421b7156f2"
           },
           "compatibilityScore": {
             "type": "number",
@@ -1484,12 +1479,47 @@
             "example": 0.85,
             "minimum": 0,
             "maximum": 1
+          },
+          "bio": {
+            "type": "string",
+            "description": "The supervisor bio",
+            "example": "Professor specializing in artificial intelligence and machine learning"
+          },
+          "tags": {
+            "description": "The supervisor tags",
+            "example": [
+              "Machine Learning",
+              "AI"
+            ],
+            "type": "array",
+            "items": {
+              "type": "array"
+            }
+          },
+          "availableSpots": {
+            "type": "number",
+            "description": "Available supervision spots",
+            "example": 3
+          },
+          "totalSpots": {
+            "type": "number",
+            "description": "Total supervision spots",
+            "example": 5
+          },
+          "pendingRequests": {
+            "type": "number",
+            "description": "Number of pending requests for this supervisor",
+            "example": 2
           }
         },
         "required": [
-          "studentId",
           "supervisorId",
-          "compatibilityScore"
+          "compatibilityScore",
+          "bio",
+          "tags",
+          "availableSpots",
+          "totalSpots",
+          "pendingRequests"
         ]
       }
     }

--- a/backend/src/modules/matching/entity/match.entity.ts
+++ b/backend/src/modules/matching/entity/match.entity.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class Match {
   @ApiProperty({
     description: 'The unique identifier of the supervisor in this match',
-    example: '5f8d0d55b54764421b7156f2',
+    example: '15d2a5bc-c547-444d-91fb-b1c498ada33c',
   })
   supervisorId: string;
 

--- a/backend/src/modules/matching/entity/match.entity.ts
+++ b/backend/src/modules/matching/entity/match.entity.ts
@@ -2,14 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class Match {
   @ApiProperty({
-    description: 'The unique identifier of the student in this match',
-    example: '15d2a5bc-c547-444d-91fb-b1c498ada33c',
-  })
-  studentId: string;
-
-  @ApiProperty({
     description: 'The unique identifier of the supervisor in this match',
-    example: '15d2a5bc-c547-444d-91fb-b1c498ada33c',
+    example: '5f8d0d55b54764421b7156f2',
   })
   supervisorId: string;
 
@@ -20,4 +14,33 @@ export class Match {
     maximum: 1,
   })
   compatibilityScore: number;
+
+  @ApiProperty({
+    description: 'The supervisor bio',
+    example: 'Professor specializing in artificial intelligence and machine learning',
+  })
+  bio: string;
+  @ApiProperty({
+    description: 'The supervisor tags',
+    example: ['Machine Learning', 'AI'],
+    isArray: true,
+  })
+  tags: string[];
+  @ApiProperty({
+    description: 'Available supervision spots',
+    example: 3,
+  })
+  availableSpots: number;
+
+  @ApiProperty({
+    description: 'Total supervision spots',
+    example: 5,
+  })
+  totalSpots: number;
+
+  @ApiProperty({
+    description: 'Number of pending requests for this supervisor',
+    example: 2,
+  })
+  pendingRequests: number;
 }


### PR DESCRIPTION
The Frontend now get more data about the supervisors within the match array of object. 

Example : 
    {
        "supervisorId": "e6527a9c-d18f-44e8-a6f0-ff0fd75517b6",
        "compatibilityScore": 0.99,
        "bio": "Professor specializing in artificial intelligence",
        "tags": [
            "Ethical Hacking",
            "Data Science",
            "Smart Engineering"
        ],
        "pendingRequests": 0,
        "availableSpots": 3,
        "totalSpots": 5
    }