### PR TITLE
Scrum 111  nest be fix tag id reference loss during bulk im

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,6 +4,7 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ValidationPipe } from '@nestjs/common';
 import * as fs from 'fs';
 import { WinstonLoggerService } from './common/logging/winston-logger.service';
+import { json } from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -13,7 +14,7 @@ async function bootstrap() {
   // Use our custom Winston logger
   const logger = app.get(WinstonLoggerService);
   app.useLogger(logger);
-
+  app.use(json({ limit: '50mb' })); // added this because the payload of bulk tag upload was too large.
   // Add validation pipe for all requests
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -14,7 +14,7 @@ async function bootstrap() {
   // Use our custom Winston logger
   const logger = app.get(WinstonLoggerService);
   app.useLogger(logger);
-  app.use(json({ limit: '50mb' })); // added this because the payload of bulk tag upload was too large.
+  app.use(json({ limit: '50mb' }));
   // Add validation pipe for all requests
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,17 +4,18 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ValidationPipe } from '@nestjs/common';
 import * as fs from 'fs';
 import { WinstonLoggerService } from './common/logging/winston-logger.service';
-import { json } from 'express';
-
+import { NestExpressApplication } from '@nestjs/platform-express';
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, {
+  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true, // Buffer logs until our custom logger is available
   });
 
   // Use our custom Winston logger
   const logger = app.get(WinstonLoggerService);
   app.useLogger(logger);
-  app.use(json({ limit: '50mb' }));
+  app.useBodyParser('json', { limit: '20mb' });
+  app.useBodyParser('urlencoded', { extended: true, limit: '20mb' });
+
   // Add validation pipe for all requests
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,6 +5,7 @@ import { ValidationPipe } from '@nestjs/common';
 import * as fs from 'fs';
 import { WinstonLoggerService } from './common/logging/winston-logger.service';
 import { NestExpressApplication } from '@nestjs/platform-express';
+
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true, // Buffer logs until our custom logger is available

--- a/backend/src/modules/admin/admin.controller.spec.ts
+++ b/backend/src/modules/admin/admin.controller.spec.ts
@@ -53,6 +53,8 @@ describe('AdminController', () => {
         message: 'Tags and similarities imported successfully',
         tagsProcessed: 3,
         similaritiesReplaced: 1,
+        duplicateTagsSkipped: 0,
+        duplicateSimsSkipped: 0,
       };
 
       // Setup mock
@@ -97,6 +99,8 @@ describe('AdminController', () => {
         message: 'Tags and similarities imported successfully',
         tagsProcessed: 0,
         similaritiesReplaced: 0,
+        duplicateTagsSkipped: 0,
+        duplicateSimsSkipped: 0,
       };
 
       // Setup mock

--- a/backend/src/modules/admin/admin.repository.ts
+++ b/backend/src/modules/admin/admin.repository.ts
@@ -17,7 +17,6 @@ export class AdminRepository {
   }> {
     return this.prisma.$transaction(
       async tx => {
-    
         const existingTags = await tx.tag.findMany({
           where: { tag_name: { in: tags } },
         });
@@ -63,14 +62,15 @@ export class AdminRepository {
         if (similaritiesData.length > 0) {
           const result = await tx.tagSimilarity.createMany({
             data: similaritiesData,
+            skipDuplicates: true,
           });
           replacedCount = result.count;
         }
 
         return {
           success: true,
-          message: 'Tags and similarities imported successfully',
-          tagsProcessed: syncedTags.length,
+          message: `${newTags.length} new tags added, ${existingTags.length} tags already existed`,
+          tagsProcessed: newTags.length,
           similaritiesReplaced: replacedCount,
         };
       },

--- a/backend/src/modules/admin/admin.service.spec.ts
+++ b/backend/src/modules/admin/admin.service.spec.ts
@@ -91,7 +91,7 @@ describe('AdminService', () => {
       // Execute & assert
       await expect(service.bulkImport(mockDto)).rejects.toThrow(BadRequestException);
       await expect(service.bulkImport(mockDto)).rejects.toThrow(
-        /Tag 'javascript' from similarities not found in provided tags list/,
+        /Tag 'javascript' not found in provided tags list./,
       );
     });
 

--- a/backend/src/modules/admin/admin.service.spec.ts
+++ b/backend/src/modules/admin/admin.service.spec.ts
@@ -59,7 +59,7 @@ describe('AdminService', () => {
       // Setup mock for bulkImport with the correct return structure
       mockBulkImport.mockResolvedValue({
         success: true,
-        message: 'Tags and similarities imported successfully',
+        message: '3 new tags added, 0 tags already existed',
         tagsProcessed: 3,
         similaritiesReplaced: 2,
       });
@@ -71,7 +71,7 @@ describe('AdminService', () => {
       expect(mockBulkImport).toHaveBeenCalledWith(mockDto.tags, mockDto.similarities);
       expect(result).toEqual({
         success: true,
-        message: 'Tags and similarities imported successfully',
+        message: '3 new tags added, 0 tags already existed',
         tagsProcessed: 3,
         similaritiesReplaced: 2,
       });
@@ -85,9 +85,7 @@ describe('AdminService', () => {
 
       // Mock the repository method to throw the expected error
       mockBulkImport.mockRejectedValue(
-        new BadRequestException(
-          "Tag 'javascript' from similarities not found in provided tags list.",
-        ),
+        new BadRequestException(`Tag 'javascript' not found in provided tags list.`),
       );
 
       // Execute & assert

--- a/backend/src/modules/admin/dto/bulk-import-success.dto.ts
+++ b/backend/src/modules/admin/dto/bulk-import-success.dto.ts
@@ -24,4 +24,16 @@ export class BulkImportSuccessDto {
     example: 15,
   })
   similaritiesReplaced: number;
+
+  @ApiProperty({
+    description: 'Number of duplicate tags skipped',
+    example: 8,
+  })
+  duplicateTagsSkipped: number;
+
+  @ApiProperty({
+    description: 'Number of duplicate similarities skipped',
+    example: 8,
+  })
+  duplicateSimsSkipped: number;
 }


### PR DESCRIPTION
Insead of deleting all tags and updating them using the imported json, the code now identifies which tags are new, and upload only those to make sure that tags ids dont change. 