### PR TITLE
feat(frontend): create csv export for currently matched students supervisors (SCRUM-125)

### DIFF
--- a/Frontend/utils/csvHelpers.ts
+++ b/Frontend/utils/csvHelpers.ts
@@ -1,13 +1,24 @@
 import Papa from 'papaparse';
 
-type AcceptedData = string | number;
+type AcceptedData = string ;
 
-interface CsvRecord {
-    [key: string]: AcceptedData;
+export interface csvMatchExportRow {
+    'Supervisor Last Name': AcceptedData;
+    'Supervisor First Name': AcceptedData;
+    'Supervisor Email': AcceptedData;
+    'Student Last Name': AcceptedData;
+    'Student First Name': AcceptedData;
+    'Student Email': AcceptedData;
 }
 
-export function exportCsv(data: CsvRecord[], filename = 'export.csv'): void {
-    const csv = Papa.unparse(data);
+// The default delimiter for German/Austrian locale is semicolon. If opened in a german excel, it will be formatted correctly
+export function exportCsv(data: csvMatchExportRow[], filename = 'export.csv', delimiter = ';'): void {
+    const config = {
+        columns: ['Supervisor Last Name', 'Supervisor First Name', 'Supervisor Email', 'Student Last Name', 'Student First Name', 'Student Email',],
+        delimiter: delimiter,
+    }
+
+    const csv = Papa.unparse(data, config);
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
 

--- a/Frontend/utils/csvHelpers.ts
+++ b/Frontend/utils/csvHelpers.ts
@@ -1,0 +1,21 @@
+import Papa from 'papaparse';
+
+type AcceptedData = string | number;
+
+interface CsvRecord {
+    [key: string]: AcceptedData;
+}
+
+export function exportCsv(data: CsvRecord[], filename = 'export.csv'): void {
+    const csv = Papa.unparse(data);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute('download', filename);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
index.vue to test:

```vue
<template>
    <CustomButton @click="handleExport">Export CSV</CustomButton>
</template>

<script setup lang="ts">
import {type csvMatchExportRow, exportCsv} from "~/utils/csvHelpers";

const handleExport = () => {
    const data: csvMatchExportRow[] = [
        {
            "Supervisor First Name": "John",
            "Supervisor Last Name": "Doe",
            "Supervisor Email": "johndoe@mail.com",
            "Student First Name": "Jane",
            "Student Last Name": "Smith",
            "Student Email": "janesmith@mail.com"
        },
        {
            "Supervisor First Name": "Alice",
            "Supervisor Last Name": "Johnson",
            "Supervisor Email": "alicejohnson@mail.com",
            "Student First Name": "Bob",
            "Student Last Name": "Brown",
            "Student Email": "bobbrown@mail.com"
        },
    ]

    exportCsv(data, 'Matches.csv');
};
</script>
```