### PR TITLE
Scrum 127 backend create user supervisor blacklist endpoint

### DIFF
--- a/backend/OpenAPI.json
+++ b/backend/OpenAPI.json
@@ -590,6 +590,142 @@
         ]
       }
     },
+    "/users/{userId}/blocks": {
+      "get": {
+        "description": "Retrieves a list of all supervisors that have been blocked by the specified student.",
+        "operationId": "UsersController_findBlockedSupervisorsByStudentUserId",
+        "parameters": [
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "description": "Student unique identifier (UUID)",
+            "schema": {
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of blocked supervisors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserBlock"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - User is not a student"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "summary": "Get all supervisors blocked by a student",
+        "tags": [
+          "Users"
+        ]
+      },
+      "post": {
+        "description": "Allows a student to block a supervisor, preventing them from appearing in recommendations.",
+        "operationId": "UsersController_createUserBlock",
+        "parameters": [
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "description": "Student unique identifier (UUID)",
+            "schema": {
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "description": "The ID of the supervisor to block",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserBlockDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Supervisor has been successfully blocked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserBlock"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid input or validation error"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "summary": "Block a supervisor",
+        "tags": [
+          "Users"
+        ]
+      }
+    },
+    "/users/{userId}/blocks/{blockedId}": {
+      "delete": {
+        "description": "Removes a block from a supervisor, allowing them to appear in recommendations again.",
+        "operationId": "UsersController_removeUserBlock",
+        "parameters": [
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "description": "Student unique identifier (UUID)",
+            "schema": {
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174000",
+              "type": "string"
+            }
+          },
+          {
+            "name": "blockedId",
+            "required": true,
+            "in": "path",
+            "description": "Supervisor unique identifier (UUID) to unblock",
+            "schema": {
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174001",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Supervisor has been successfully unblocked"
+          },
+          "404": {
+            "description": "User or block relationship not found"
+          }
+        },
+        "summary": "Unblock a supervisor",
+        "tags": [
+          "Users"
+        ]
+      }
+    },
     "/tags": {
       "get": {
         "description": "Retrieves a list of all available tags in the system that can be used for searching and filtering users.",
@@ -1851,6 +1987,55 @@
         },
         "required": [
           "tags"
+        ]
+      },
+      "UserBlock": {
+        "type": "object",
+        "properties": {
+          "blocker_id": {
+            "type": "string",
+            "description": "ID of the user who initiated the block",
+            "example": "123e4567-e89b-12d3-a456-426614174000",
+            "format": "uuid"
+          },
+          "blocked_id": {
+            "type": "string",
+            "description": "ID of the user who is being blocked",
+            "example": "123e4567-e89b-12d3-a456-426614174001",
+            "format": "uuid"
+          },
+          "created_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Timestamp when the block was created",
+            "example": "2023-01-01T00:00:00Z"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Timestamp when the block was last updated",
+            "example": "2023-01-01T00:00:00Z"
+          }
+        },
+        "required": [
+          "blocker_id",
+          "blocked_id",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CreateUserBlockDto": {
+        "type": "object",
+        "properties": {
+          "blocked_id": {
+            "type": "string",
+            "description": "ID of the user to block",
+            "example": "123e4567-e89b-12d3-a456-426614174001",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "blocked_id"
         ]
       },
       "TagSimilarity": {

--- a/backend/src/modules/users/dto/create-user-block.dto.ts
+++ b/backend/src/modules/users/dto/create-user-block.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class CreateUserBlockDto {
+  @ApiProperty({
+    description: 'ID of the user to block',
+    example: '123e4567-e89b-12d3-a456-426614174001',
+    format: 'uuid',
+  })
+  @IsUUID('4', { message: 'blocked_id must be a valid UUID v4' })
+  blocked_id: string;
+}

--- a/backend/src/modules/users/entities/user-block.entity.ts
+++ b/backend/src/modules/users/entities/user-block.entity.ts
@@ -1,5 +1,4 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { User } from './user.entity'; // Assuming user.entity.ts exists
 
 export class UserBlock {
   @ApiProperty({
@@ -15,18 +14,6 @@ export class UserBlock {
     format: 'uuid',
   })
   blocked_id: string;
-
-  @ApiProperty({
-    description: 'Full user object of the user who initiated the block',
-    type: () => User,
-  })
-  blocker: User;
-
-  @ApiProperty({
-    description: 'Full user object of the user who is being blocked',
-    type: () => User,
-  })
-  blocked: User;
 
   @ApiProperty({
     description: 'Timestamp when the block was created',


### PR DESCRIPTION
Added student-supervisor blacklist functionality:

- Created new endpoints so students can block/unblock supervisors they don't want to work with
- Updated the matching service to filter out blocked supervisors from recommendations
- Added proper authorization checks (only students can block supervisors)
- Added comprehensive test coverage at all layers

So now students can dismiss unwanted supervisors from their recommendation list.