### PR TITLE
feat(backend): filter out unregistered supervisors from matching recommendations (SCRUM-195)

### DIFF
--- a/backend/OpenAPI.json
+++ b/backend/OpenAPI.json
@@ -2418,6 +2418,12 @@
             "description": "The supervisor's last name",
             "example": "Smith"
           },
+          "profileImage": {
+            "type": "object",
+            "description": "The supervisor's profile image URL",
+            "example": "https://example.com/profile.jpg",
+            "nullable": true
+          },
           "compatibilityScore": {
             "type": "number",
             "description": "Compatibility score between student and supervisor (0-1)",
@@ -2462,6 +2468,7 @@
           "supervisor_userId",
           "firstName",
           "lastName",
+          "profileImage",
           "compatibilityScore",
           "bio",
           "tags",
@@ -2560,12 +2567,19 @@
             "type": "string",
             "description": "User email",
             "example": "john.doe@fhstp.ac.at"
+          },
+          "profile_image": {
+            "type": "object",
+            "description": "User profile image URL",
+            "example": "https://example.com/profile.jpg",
+            "nullable": true
           }
         },
         "required": [
           "first_name",
           "last_name",
-          "email"
+          "email",
+          "profile_image"
         ]
       },
       "StudentWithUser": {

--- a/backend/src/modules/matching/matching.service.spec.ts
+++ b/backend/src/modules/matching/matching.service.spec.ts
@@ -536,5 +536,25 @@ describe('MatchingService', () => {
       // Verify that the supervisor with a pending request was properly filtered out
       expect(result.some(match => match.supervisorId === SUPERVISOR_UUID_1)).toBeFalsy();
     });
+
+    it('should call findAllSupervisors with includeRegisteredOnly=true', async () => {
+      // Set up mocks
+      studentsService.findStudentByUserId.mockResolvedValue(mockStudentProfile);
+      supervisionRequestsService.findAllRequests.mockResolvedValue([]);
+      supervisorsService.findAllSupervisors.mockResolvedValue([]);
+      usersService.findBlockedSupervisorsByStudentUserId.mockResolvedValue([]);
+      usersService.findUserTagsByUserId.mockResolvedValue([]);
+
+      // Execute
+      await service.calculateAllMatchesForUserId(STUDENT_UUID);
+
+      // Verify the supervisors service was called with includeRegisteredOnly=true
+      expect(supervisorsService.findAllSupervisors).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.any(Object),
+          includeRegisteredOnly: true,
+        }),
+      );
+    });
   });
 });

--- a/backend/src/modules/matching/matching.service.ts
+++ b/backend/src/modules/matching/matching.service.ts
@@ -33,6 +33,7 @@ export class MatchingService {
           gt: 0,
         },
       },
+      includeRegisteredOnly: true,
     });
 
     // Get list of supervisors blocked by this student

--- a/backend/src/modules/supervisors/supervisors.repository.ts
+++ b/backend/src/modules/supervisors/supervisors.repository.ts
@@ -23,14 +23,31 @@ export class SupervisorsRepository {
     take?: number;
     where?: Prisma.SupervisorWhereInput;
     orderBy?: Prisma.SupervisorOrderByWithRelationInput;
+    includeRegisteredOnly?: boolean;
   }): Promise<Supervisor[]> {
-    const { take, where, orderBy } = params;
+    const { take, where, orderBy, includeRegisteredOnly } = params;
 
-    return this.prisma.supervisor.findMany({
+    // Create query with user relation for registration check
+    const query: Prisma.SupervisorFindManyArgs = {
       take,
       where,
       orderBy,
-    });
+      include: {
+        user: includeRegisteredOnly ? true : undefined,
+      },
+    };
+
+    // If we need to filter by registration status, add the condition to where
+    if (includeRegisteredOnly) {
+      query.where = {
+        ...query.where,
+        user: {
+          is_registered: true,
+        },
+      };
+    }
+
+    return this.prisma.supervisor.findMany(query);
   }
 
   async updateSupervisorProfile(

--- a/backend/src/modules/supervisors/supervisors.service.spec.ts
+++ b/backend/src/modules/supervisors/supervisors.service.spec.ts
@@ -50,8 +50,17 @@ describe('SupervisorsService', () => {
       const result = await service.findAllSupervisors({});
 
       expect(result).toEqual([mockSupervisor]);
-
       expect(repository.findAllSupervisors).toHaveBeenCalledWith({});
+    });
+
+    it('should pass includeRegisteredOnly parameter to repository', async () => {
+      repository.findAllSupervisors.mockResolvedValue([mockSupervisor]);
+
+      await service.findAllSupervisors({ includeRegisteredOnly: true });
+
+      expect(repository.findAllSupervisors).toHaveBeenCalledWith({
+        includeRegisteredOnly: true,
+      });
     });
   });
 

--- a/backend/src/modules/supervisors/supervisors.service.ts
+++ b/backend/src/modules/supervisors/supervisors.service.ts
@@ -29,6 +29,7 @@ export class SupervisorsService {
     take?: number;
     where?: Prisma.SupervisorWhereInput;
     orderBy?: Prisma.SupervisorOrderByWithRelationInput;
+    includeRegisteredOnly?: boolean;
   }) {
     return this.supervisorsRepository.findAllSupervisors(params);
   }


### PR DESCRIPTION
**Key changes:**

- Updated `MatchingService` to filter out supervisors with existing `PENDING`/`PENDING` requests
- add `includeRegisteredOnly` parameter to only show registered users in `SupervisorsService`
- Updated relevant tests to verify filtering functionality

