### PR TITLE
feat(backend): add admin creation endpoint (SCRUM-194)

### DIFF
--- a/Frontend/server/api/admin/create-admin/index.post.ts
+++ b/Frontend/server/api/admin/create-admin/index.post.ts
@@ -1,0 +1,33 @@
+import {createAdminSchema} from "#shared/validationSchemas/validationSchemas";
+
+export default defineEventHandler ( async (event) => {
+    // specific checks for this endpoint
+    const validatedBody = await readValidatedBody(event, body => createAdminSchema.safeParse(body))
+    if (!validatedBody.success) {
+        throw createError({
+            statusCode: 400,
+            statusMessage: validatedBody.error.errors.map(err =>
+                `${err.path.join('.')}: ${err.message}`
+            ).join('; ') || 'Invalid request body',
+    })}
+
+    const body = validatedBody.data
+
+    // standard setup for every endpoint
+    const token = await getBearerToken(event)
+    const targetPath = getTargetPath(event)
+
+    // Send request to Nest API
+    return await fetchNest(targetPath, {
+        method: event.method,
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+        body: body,
+    }).catch((error) => {
+        throw createError({
+            statusCode: error.statusCode || 500,
+            statusMessage: error.message || 'Internal Server Error',
+        })
+    })
+})

--- a/Frontend/shared/validationSchemas/validationSchemas.ts
+++ b/Frontend/shared/validationSchemas/validationSchemas.ts
@@ -147,3 +147,9 @@ export const createSupervisionRequestSchema = z.object({
 export const updateSupervisionRequestStateScheme = z.object({
     request_state: requestStateSchema
 })
+
+export const createAdminSchema = z.object({
+    email: z.string().email("Email must be a valid email address"),
+    first_name: z.string().min(1, "First name cannot be empty"),
+    last_name: z.string().min(1, "Last name cannot be empty"),
+})

--- a/backend/OpenAPI.json
+++ b/backend/OpenAPI.json
@@ -1361,6 +1361,46 @@
         ]
       }
     },
+    "/admin/create-admin": {
+      "post": {
+        "description": "Creates a new admin user account that is not yet registered with the authentication provider (Clerk). This endpoint allows existing admins to pre-create admin accounts that can later be claimed through the standard registration flow.",
+        "operationId": "AdminController_createAdmin",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "description": "Admin user details including email, first name, and last name",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAdminDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Admin user created successfully. Returns the new admin user ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateAdminSuccessDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - Invalid email domain, missing required fields, or user already exists."
+          },
+          "403": {
+            "description": "Forbidden - Only existing admins can create new admin accounts."
+          }
+        },
+        "summary": "Create a new unregistered admin user",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
     "/match/{userId}": {
       "get": {
         "description": "Calculate and retrieve a list of all supervisors with their compatibility scores for a specific student",
@@ -2393,6 +2433,56 @@
         },
         "required": [
           "supervisors"
+        ]
+      },
+      "CreateAdminDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "Email address of the admin user",
+            "example": "admin@fhstp.ac.at"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "First name of the admin user",
+            "example": "John"
+          },
+          "last_name": {
+            "type": "string",
+            "description": "Last name of the admin user",
+            "example": "Doe"
+          }
+        },
+        "required": [
+          "email",
+          "first_name",
+          "last_name"
+        ]
+      },
+      "CreateAdminSuccessDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Success flag",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "description": "Success message",
+            "example": "Admin user created successfully"
+          },
+          "adminId": {
+            "type": "string",
+            "description": "ID of the created admin user",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          }
+        },
+        "required": [
+          "success",
+          "message",
+          "adminId"
         ]
       },
       "Match": {

--- a/backend/src/common/exceptions/custom-exceptions/user-already-exists.exception.ts
+++ b/backend/src/common/exceptions/custom-exceptions/user-already-exists.exception.ts
@@ -1,0 +1,8 @@
+import { ConflictException } from '@nestjs/common';
+
+export class UserAlreadyExistsException extends ConflictException {
+  constructor(email: string) {
+    super(`User with email ${email} already exists`);
+    this.name = 'UserAlreadyExistsException';
+  }
+}

--- a/backend/src/modules/admin/admin.controller.spec.ts
+++ b/backend/src/modules/admin/admin.controller.spec.ts
@@ -7,10 +7,22 @@ import { TagsBulkImportDto } from './dto/tags-bulk-import.dto';
 import { SupervisorsBulkImportDto } from './dto/supervisors-bulk-import.dto';
 import { AdminRepository } from './admin.repository';
 import { SupervisorsRepository } from '../supervisors/supervisors.repository';
+import { CreateAdminDto } from './dto/create-admin.dto';
+import { UserAlreadyExistsException } from '../../common/exceptions/custom-exceptions/user-already-exists.exception';
 
 describe('AdminController', () => {
   let controller: AdminController;
   let service: AdminService;
+
+  // Proper UUIDs for testing
+  const ADMIN_USER_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+  // Create mock service object with all methods
+  const mockAdminService = {
+    tagsBulkImport: jest.fn(),
+    supervisorsBulkImport: jest.fn(),
+    createAdmin: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -18,30 +30,7 @@ describe('AdminController', () => {
       providers: [
         {
           provide: AdminService,
-          useValue: {
-            tagsBulkImport: jest.fn(),
-            supervisorsBulkImport: jest.fn(),
-          },
-        },
-        {
-          provide: AdminRepository,
-          useValue: {
-            tagsBulkImport: jest.fn(),
-            supervisorsBulkImport: jest.fn(),
-          },
-        },
-        {
-          provide: SupervisorsRepository,
-          useValue: {
-            findSupervisorByUserId: jest.fn(),
-            findAllSupervisors: jest.fn(),
-          },
-        },
-        {
-          provide: PrismaService,
-          useValue: {
-            $transaction: jest.fn(),
-          },
+          useValue: mockAdminService,
         },
       ],
     }).compile();
@@ -50,93 +39,71 @@ describe('AdminController', () => {
     service = module.get<AdminService>(AdminService);
   });
 
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
 
   describe('tagsBulkImport', () => {
-    it('should call the service method with the provided DTO', async () => {
-      // Mock data
+    it('should call service.tagsBulkImport and return its result', async () => {
+      // Arrange
       const mockDto: TagsBulkImportDto = {
         tags: ['javascript', 'python', 'react'],
-        similarities: [{ field1: 'javascript', field2: 'react', similarity_score: 0.8 }],
+        similarities: [
+          { field1: 'javascript', field2: 'react', similarity_score: 0.8 },
+          { field1: 'python', field2: 'javascript', similarity_score: 0.5 },
+        ],
       };
 
       const mockResponse = {
         success: true,
-        message: 'Tags and similarities imported successfully',
+        message: '3 new tags added, 0 tags already existed',
         tagsProcessed: 3,
-        similaritiesReplaced: 1,
+        similaritiesReplaced: 2,
         duplicateTagsSkipped: 0,
         duplicateSimsSkipped: 0,
       };
 
-      // Setup mock
-      const bulkImportSpy = jest.spyOn(service, 'tagsBulkImport').mockResolvedValue(mockResponse);
+      mockAdminService.tagsBulkImport.mockResolvedValue(mockResponse);
 
-      // Execute
+      // Act
       const result = await controller.tagsBulkImport(mockDto);
 
-      // Assertions
-      expect(bulkImportSpy).toHaveBeenCalledWith(mockDto);
+      // Assert
+      expect(service.tagsBulkImport).toHaveBeenCalledWith(mockDto);
       expect(result).toEqual(mockResponse);
     });
 
-    it('should propagate errors from the service', async () => {
-      // Mock data
+    it('should pass through BadRequestException from service', async () => {
+      // Arrange
       const mockDto: TagsBulkImportDto = {
-        tags: ['javascript', 'python'],
-        similarities: [{ field1: 'javascript', field2: 'react', similarity_score: 0.8 }],
+        tags: ['javascript'],
+        similarities: [
+          { field1: 'javascript', field2: 'nodejs', similarity_score: 0.8 }, // nodejs not in tags
+        ],
       };
 
-      const mockError = new BadRequestException(
-        "Tag 'react' from similarities not found in provided tags list.",
+      mockAdminService.tagsBulkImport.mockRejectedValue(
+        new BadRequestException("Tag 'react' not found in provided tags list."),
       );
 
-      // Setup mock to throw error
-      const bulkImportSpy = jest.spyOn(service, 'tagsBulkImport').mockRejectedValue(mockError);
-
-      // Execute & assert
+      // Act & Assert
       await expect(controller.tagsBulkImport(mockDto)).rejects.toThrow(BadRequestException);
-      expect(bulkImportSpy).toHaveBeenCalledWith(mockDto);
-    });
-
-    it('should handle empty tags and similarities', async () => {
-      // Mock data with empty arrays
-      const mockDto: TagsBulkImportDto = {
-        tags: [],
-        similarities: [],
-      };
-
-      const mockResponse = {
-        success: true,
-        message: 'Tags and similarities imported successfully',
-        tagsProcessed: 0,
-        similaritiesReplaced: 0,
-        duplicateTagsSkipped: 0,
-        duplicateSimsSkipped: 0,
-      };
-
-      // Setup mock
-      const bulkImportSpy = jest.spyOn(service, 'tagsBulkImport').mockResolvedValue(mockResponse);
-
-      // Execute
-      const result = await controller.tagsBulkImport(mockDto);
-
-      // Assertions
-      expect(bulkImportSpy).toHaveBeenCalledWith(mockDto);
-      expect(result).toEqual(mockResponse);
+      expect(service.tagsBulkImport).toHaveBeenCalledWith(mockDto);
     });
   });
 
   describe('supervisorsBulkImport', () => {
-    it('should call the service method with the provided DTO', async () => {
-      // Mock data
+    it('should call service.supervisorsBulkImport and return its result', async () => {
+      // Arrange
       const mockDto: SupervisorsBulkImportDto = {
         supervisors: [
           {
-            email: 'supervisor1@example.com',
-            first_name: 'John',
+            email: 'supervisor@fhstp.ac.at',
+            first_name: 'Jane',
             last_name: 'Doe',
             total_spots: 5,
             available_spots: 3,
@@ -151,68 +118,78 @@ describe('AdminController', () => {
         supervisorsUpdated: 0,
       };
 
-      // Setup mock
-      const bulkImportSpy = jest
-        .spyOn(service, 'supervisorsBulkImport')
-        .mockResolvedValue(mockResponse);
+      mockAdminService.supervisorsBulkImport.mockResolvedValue(mockResponse);
 
-      // Execute
+      // Act
       const result = await controller.supervisorsBulkImport(mockDto);
 
-      // Assertions
-      expect(bulkImportSpy).toHaveBeenCalledWith(mockDto);
+      // Assert
+      expect(service.supervisorsBulkImport).toHaveBeenCalledWith(mockDto);
       expect(result).toEqual(mockResponse);
     });
 
-    it('should propagate errors from the service', async () => {
-      // Mock data with missing required fields
+    it('should pass through BadRequestException from service', async () => {
+      // Arrange
       const mockDto: SupervisorsBulkImportDto = {
         supervisors: [
           {
-            email: 'supervisor1@example.com',
-            // Missing first_name and last_name
+            email: '', // Missing email
+            first_name: 'Jane',
+            last_name: 'Doe',
           },
         ],
       };
 
-      const mockError = new BadRequestException(
-        'First name and last name are required when creating a new supervisor with email: supervisor1@example.com',
+      mockAdminService.supervisorsBulkImport.mockRejectedValue(
+        new BadRequestException('Email is required for supervisor: Doe'),
       );
 
-      // Setup mock to throw error
-      const bulkImportSpy = jest
-        .spyOn(service, 'supervisorsBulkImport')
-        .mockRejectedValue(mockError);
-
-      // Execute & assert
+      // Act & Assert
       await expect(controller.supervisorsBulkImport(mockDto)).rejects.toThrow(BadRequestException);
-      expect(bulkImportSpy).toHaveBeenCalledWith(mockDto);
+      expect(service.supervisorsBulkImport).toHaveBeenCalledWith(mockDto);
     });
+  });
 
-    it('should handle empty supervisors array', async () => {
-      // Mock data with empty array
-      const mockDto: SupervisorsBulkImportDto = {
-        supervisors: [],
+  describe('createAdmin', () => {
+    it('should call service.createAdmin and return its result', async () => {
+      // Arrange
+      const mockDto: CreateAdminDto = {
+        email: 'admin@fhstp.ac.at',
+        first_name: 'John',
+        last_name: 'Doe',
       };
 
       const mockResponse = {
         success: true,
-        message: 'No supervisors imported or updated',
-        supervisorsImported: 0,
-        supervisorsUpdated: 0,
+        message: 'Admin user created successfully',
+        adminId: ADMIN_USER_ID,
       };
 
-      // Setup mock
-      const bulkImportSpy = jest
-        .spyOn(service, 'supervisorsBulkImport')
-        .mockResolvedValue(mockResponse);
+      mockAdminService.createAdmin.mockResolvedValue(mockResponse);
 
-      // Execute
-      const result = await controller.supervisorsBulkImport(mockDto);
+      // Act
+      const result = await controller.createAdmin(mockDto);
 
-      // Assertions
-      expect(bulkImportSpy).toHaveBeenCalledWith(mockDto);
+      // Assert
+      expect(service.createAdmin).toHaveBeenCalledWith(mockDto);
       expect(result).toEqual(mockResponse);
+    });
+
+    it('should pass through UserAlreadyExistsException when email already exists', async () => {
+      // Arrange
+      const mockDto: CreateAdminDto = {
+        email: 'existing@fhstp.ac.at',
+        first_name: 'John',
+        last_name: 'Doe',
+      };
+
+      mockAdminService.createAdmin.mockRejectedValue(
+        new UserAlreadyExistsException('existing@fhstp.ac.at'),
+      );
+
+      // Act & Assert
+      await expect(controller.createAdmin(mockDto)).rejects.toThrow(UserAlreadyExistsException);
+      expect(service.createAdmin).toHaveBeenCalledWith(mockDto);
     });
   });
 });

--- a/backend/src/modules/admin/admin.controller.ts
+++ b/backend/src/modules/admin/admin.controller.ts
@@ -7,6 +7,8 @@ import { Roles } from '../../common/decorators/roles.decorator';
 import { Role } from '@prisma/client';
 import { SupervisorsBulkImportDto } from './dto/supervisors-bulk-import.dto';
 import { SupervisorsBulkImportSuccessDto } from './dto/supervisors-bulk-import-success.dto';
+import { CreateAdminDto } from './dto/create-admin.dto';
+import { CreateAdminSuccessDto } from './dto/create-admin-success.dto';
 
 @ApiTags('admin')
 @Controller('admin')
@@ -65,5 +67,37 @@ export class AdminController {
     @Body() dto: SupervisorsBulkImportDto,
   ): Promise<SupervisorsBulkImportSuccessDto> {
     return this.adminService.supervisorsBulkImport(dto);
+  }
+
+  @Post('create-admin')
+  @ApiOperation({
+    summary: 'Create a new unregistered admin user',
+    description:
+      'Creates a new admin user account that is not yet registered with the authentication provider (Clerk). This endpoint allows existing admins to pre-create admin accounts that can later be claimed through the standard registration flow.',
+  })
+  @ApiBody({
+    type: CreateAdminDto,
+    description: 'Admin user details including email, first name, and last name',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Admin user created successfully. Returns the new admin user ID.',
+    type: CreateAdminSuccessDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Bad Request - Invalid email domain, missing required fields, or user already exists.',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden - Only existing admins can create new admin accounts.',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Conflict - User with this email already exists.',
+  })
+  async createAdmin(@Body() dto: CreateAdminDto): Promise<CreateAdminSuccessDto> {
+    return this.adminService.createAdmin(dto);
   }
 }

--- a/backend/src/modules/admin/admin.module.ts
+++ b/backend/src/modules/admin/admin.module.ts
@@ -4,9 +4,10 @@ import { AdminController } from './admin.controller';
 import { AdminRepository } from './admin.repository';
 import { PrismaModule } from '../../prisma/prisma.module';
 import { TagsModule } from '../tags/tags.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [PrismaModule, TagsModule],
+  imports: [PrismaModule, TagsModule, UsersModule],
   controllers: [AdminController],
   providers: [AdminService, AdminRepository],
 })

--- a/backend/src/modules/admin/admin.service.ts
+++ b/backend/src/modules/admin/admin.service.ts
@@ -1,20 +1,84 @@
 import { Injectable } from '@nestjs/common';
 import { AdminRepository } from './admin.repository';
+import { UsersRepository } from '../users/users.repository';
 import { TagsBulkImportDto } from './dto/tags-bulk-import.dto';
 import { TagsBulkImportSuccessDto } from './dto/tags-bulk-import-success.dto';
 import { SupervisorsBulkImportDto } from './dto/supervisors-bulk-import.dto';
 import { SupervisorsBulkImportSuccessDto } from './dto/supervisors-bulk-import-success.dto';
+import { CreateAdminDto } from './dto/create-admin.dto';
+import { CreateAdminSuccessDto } from './dto/create-admin-success.dto';
+import { UserAlreadyExistsException } from '../../common/exceptions/custom-exceptions/user-already-exists.exception';
+import { WinstonLoggerService } from '../../common/logging/winston-logger.service';
+
 @Injectable()
 export class AdminService {
-  constructor(private readonly adminRepository: AdminRepository) {}
+  constructor(
+    private readonly adminRepository: AdminRepository,
+    private readonly usersRepository: UsersRepository,
+    private readonly logger: WinstonLoggerService,
+  ) {}
 
+  /**
+   * Bulk imports tags and their similarity relationships
+   *
+   * This method is essential for initial system setup and periodic updates
+   * of the tag ecosystem that drives the matching algorithm
+   * @param dto - Contains arrays of tags and their similarity scores
+   * @returns Success response with import statistics
+   */
   async tagsBulkImport(dto: TagsBulkImportDto): Promise<TagsBulkImportSuccessDto> {
     return this.adminRepository.tagsBulkImport(dto.tags, dto.similarities);
   }
 
+  /**
+   * Bulk imports supervisor accounts with their availability settings
+   *
+   * Enables efficient onboarding of multiple supervisors, typically used
+   * at the start of each academic term or when new faculty joins
+   * @param dto - Contains array of supervisor data including capacity
+   * @returns Success response with import/update counts
+   */
   async supervisorsBulkImport(
     dto: SupervisorsBulkImportDto,
   ): Promise<SupervisorsBulkImportSuccessDto> {
     return this.adminRepository.supervisorsBulkImport(dto.supervisors);
+  }
+
+  /**
+   * Creates a new unregistered admin user account
+   *
+   * Allows existing admins to pre-create admin accounts that can be claimed
+   * later through the standard Clerk authentication flow. This follows the
+   * same pattern as supervisor account creation for consistency
+   * @param dto - Admin user details (email, first name, last name)
+   * @returns Success response with the new admin's user ID
+   * @throws UserAlreadyExistsException if email is already in use
+   */
+  async createAdmin(dto: CreateAdminDto): Promise<CreateAdminSuccessDto> {
+    // Check if user already exists
+    const existingUser = await this.usersRepository.findUserByEmail(dto.email);
+
+    if (existingUser) {
+      this.logger.warn(`Attempt to create admin with existing email: ${dto.email}`, 'AdminService');
+      throw new UserAlreadyExistsException(dto.email);
+    }
+
+    this.logger.log(`Creating new admin user with email: ${dto.email}`, 'AdminService');
+
+    // Create the admin user
+    const newAdmin = await this.adminRepository.createAdmin({
+      email: dto.email,
+      first_name: dto.first_name,
+      last_name: dto.last_name,
+    });
+
+    this.logger.log(`Successfully created admin user with ID: ${newAdmin.id}`, 'AdminService');
+
+    // Return formatted response
+    return {
+      success: true,
+      message: 'Admin user created successfully',
+      adminId: newAdmin.id,
+    };
   }
 }

--- a/backend/src/modules/admin/dto/create-admin-success.dto.ts
+++ b/backend/src/modules/admin/dto/create-admin-success.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateAdminSuccessDto {
+  @ApiProperty({
+    description: 'Success flag',
+    example: true,
+  })
+  success: boolean;
+
+  @ApiProperty({
+    description: 'Success message',
+    example: 'Admin user created successfully',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: 'ID of the created admin user',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  adminId: string;
+}

--- a/backend/src/modules/admin/dto/create-admin.dto.ts
+++ b/backend/src/modules/admin/dto/create-admin.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsString, IsNotEmpty } from 'class-validator';
+import { IsAllowedEmailDomain } from '../../../common/validators/allowed-email-domains.validator';
+
+export class CreateAdminDto {
+  @ApiProperty({
+    description: 'Email address of the admin user',
+    example: 'admin@fhstp.ac.at',
+    required: true,
+  })
+  @IsEmail()
+  @IsNotEmpty()
+  @IsAllowedEmailDomain({
+    message: 'Email must be from an allowed domain',
+  })
+  email: string;
+
+  @ApiProperty({
+    description: 'First name of the admin user',
+    example: 'John',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  first_name: string;
+
+  @ApiProperty({
+    description: 'Last name of the admin user',
+    example: 'Doe',
+    required: true,
+  })
+  @IsString()
+  @IsNotEmpty()
+  last_name: string;
+}

--- a/backend/src/modules/matching/matching.service.spec.ts
+++ b/backend/src/modules/matching/matching.service.spec.ts
@@ -530,7 +530,7 @@ describe('MatchingService', () => {
       // Verify that the supervisionRequestsService was called
       expect(supervisionRequestsService.findAllRequests).toHaveBeenCalledWith(
         STUDENT_UUID,
-        'STUDENT',
+        Role.STUDENT,
       );
 
       // Verify that the supervisor with a pending request was properly filtered out

--- a/backend/src/modules/matching/matching.service.ts
+++ b/backend/src/modules/matching/matching.service.ts
@@ -6,7 +6,7 @@ import { TagsService } from '../tags/tags.service';
 import { UserTag } from '../users/entities/user-tag.entity';
 import { safeStringify } from '../../common/utils/string-utils';
 import { SupervisionRequestsService } from '../requests/supervision/supervision-requests.service';
-import { RequestState } from '@prisma/client';
+import { RequestState, Role } from '@prisma/client';
 
 @Injectable()
 export class MatchingService {
@@ -44,7 +44,7 @@ export class MatchingService {
     // Get student's supervision requests
     const activeRequests = await this.supervisionRequestsService.findAllRequests(
       studentUserId,
-      'STUDENT',
+      Role.STUDENT,
     );
 
     // Extract supervisor IDs from pending and accepted requests

--- a/backend/src/modules/requests/supervision/supervision-requests.repository.spec.ts
+++ b/backend/src/modules/requests/supervision/supervision-requests.repository.spec.ts
@@ -240,7 +240,7 @@ describe('SupervisionRequestsRepository', () => {
         email,
         first_name: 'Student',
         last_name: 'User',
-        role: 'STUDENT',
+        role: Role.STUDENT,
         is_registered: true,
       };
       const existingStudent = {
@@ -279,7 +279,7 @@ describe('SupervisionRequestsRepository', () => {
         email,
         first_name: '',
         last_name: '',
-        role: 'STUDENT',
+        role: Role.STUDENT,
         is_registered: false,
       };
       const newStudent = {
@@ -310,7 +310,7 @@ describe('SupervisionRequestsRepository', () => {
           email,
           first_name: '',
           last_name: '',
-          role: 'STUDENT',
+          role: Role.STUDENT,
           is_registered: false,
         },
       });
@@ -329,7 +329,7 @@ describe('SupervisionRequestsRepository', () => {
         email,
         first_name: 'Existing',
         last_name: 'User',
-        role: 'STUDENT',
+        role: Role.STUDENT,
         is_registered: true,
       };
       const newStudent = {

--- a/backend/src/modules/requests/supervision/supervision-requests.repository.ts
+++ b/backend/src/modules/requests/supervision/supervision-requests.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../prisma/prisma.service';
-import { Prisma, RequestState, SupervisionRequest } from '@prisma/client';
+import { Prisma, RequestState, Role, SupervisionRequest } from '@prisma/client';
 import { SupervisionRequestWithUsersEntity } from './entities/supervision-request-with-users.entity';
 
 @Injectable()
@@ -116,7 +116,7 @@ export class SupervisionRequestsRepository {
           email,
           first_name: '',
           last_name: '',
-          role: 'STUDENT',
+          role: Role.STUDENT,
           is_registered: false,
         },
       });


### PR DESCRIPTION
## Summary
Adds the ability for existing admins to create new unregistered admin users through a dedicated endpoint.

## Changes
- **New endpoint**: `POST /admin/create-admin` with proper Swagger documentation
- **Integration**: Updated `UsersService` to handle non-registered admin creation flow
- **Error handling**: Added `UserAlreadyExistsException` for duplicate email cases
- Added unit tests for all layers
- Refactored to use `Role` enum consistently instead of **_magic strings_** across the codebase

## Technical Details
- Admin users are created with `is_registered: false` same as supervisors, when added by admin
- The created admin can later claim their account through the standard Clerk authentication flow