### PR TITLE
feat(frontend): Add confirmation timestamp to CSV export (SCRUM-204)

### DIFF
--- a/Frontend/pages/admin/download.vue
+++ b/Frontend/pages/admin/download.vue
@@ -29,6 +29,17 @@ const downloadConfirmedSupervisions = () => {
                     "Student First Name": request.student.user.first_name,
                     "Student Last Name": request.student.user.last_name,
                     "Student Email": request.student.user.email,
+                    "Confirmed at": request.updated_at ?
+                        new Date(request.updated_at).toLocaleString('en-US', {
+                            year: 'numeric',
+                            month: 'long',
+                            day: 'numeric',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            hour12: false
+                        }
+                        )
+                        : "No Date Available",
                 }
             });
             exportCsv(csvData, "confirmed_supervisions.csv");

--- a/Frontend/utils/csvHelpers.ts
+++ b/Frontend/utils/csvHelpers.ts
@@ -9,12 +9,13 @@ export interface csvMatchExportRow {
     'Student Last Name': AcceptedData;
     'Student First Name': AcceptedData;
     'Student Email': AcceptedData;
+    'Confirmed at': AcceptedData;
 }
 
 // The default delimiter for German/Austrian locale is semicolon. If opened in a german excel, it will be formatted correctly
 export function exportCsv(data: csvMatchExportRow[], filename = 'export.csv', delimiter = ';'): void {
     const config = {
-        columns: ['Supervisor Last Name', 'Supervisor First Name', 'Supervisor Email', 'Student Last Name', 'Student First Name', 'Student Email',],
+        columns: ['Supervisor Last Name', 'Supervisor First Name', 'Supervisor Email', 'Student Last Name', 'Student First Name', 'Student Email', 'Confirmed at'],
         delimiter: delimiter,
     }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1854a896-232a-4bba-a46d-a527edbb8404)
