### PR TITLE
fix(frontend): make navbar labels always visible (SCRUM-266)

### DIFF
--- a/Frontend/components/BottomNav/BottomNav.vue
+++ b/Frontend/components/BottomNav/BottomNav.vue
@@ -14,7 +14,7 @@ interface Props {
     showLabelsOnActive?: boolean;
 }
 const props = withDefaults(defineProps<Props>(), {
-        alwaysShowLabels: false,
+        alwaysShowLabels: true,
         showLabelsOnActive: true
 });
 

--- a/Frontend/pages/student/dashboard.vue
+++ b/Frontend/pages/student/dashboard.vue
@@ -159,7 +159,6 @@
 
       <div>
         <BottomNav
-            :always-show-labels="false"
             :bottom-nav-buttons="bottomNavButtons"
             @navigate="navigate"
         />

--- a/Frontend/pages/student/matching.vue
+++ b/Frontend/pages/student/matching.vue
@@ -72,7 +72,6 @@
 
       <div class="">
         <BottomNav
-            :always-show-labels="false"
             :bottom-nav-buttons="bottomNavButtons"
             @navigate="navigate"
         />

--- a/Frontend/pages/student/requests.vue
+++ b/Frontend/pages/student/requests.vue
@@ -40,7 +40,6 @@ function navigate(route: string) {
       </div>
       <div>
         <BottomNav
-            :always-show-labels="false"
             :bottom-nav-buttons="bottomNavButtons"
             @navigate="navigate"
         />

--- a/Frontend/pages/supervisor/confirmed.vue
+++ b/Frontend/pages/supervisor/confirmed.vue
@@ -108,7 +108,6 @@ const bottomNavButtons = [
       </div>
       <div>
         <BottomNav
-            :always-show-labels="false"
             :bottom-nav-buttons="bottomNavButtons"
             @navigate="navigate"
         />

--- a/Frontend/pages/supervisor/dashboard.vue
+++ b/Frontend/pages/supervisor/dashboard.vue
@@ -134,7 +134,6 @@ const bottomNavButtons = [
         </ActionCard>
 
         <BottomNav
-          :always-show-labels="false"
           :bottom-nav-buttons="bottomNavButtons"
           @navigate="navigate"
         />

--- a/Frontend/pages/supervisor/matching.vue
+++ b/Frontend/pages/supervisor/matching.vue
@@ -32,7 +32,6 @@
 
       <div>
         <BottomNav
-            :always-show-labels="false"
             :bottom-nav-buttons="bottomNavButtons"
             @navigate="navigate"
         />


### PR DESCRIPTION
The labels are now always visible because of user feedback
![image](https://github.com/user-attachments/assets/017a4f31-8e63-4afd-bea7-8c8db8717f26)
