### PR TITLE
SCRUM-262: Nuxt FE(feature): Fix matching requests not sending until the toast disappears

### DIFF
--- a/Frontend/pages/student/matching.vue
+++ b/Frontend/pages/student/matching.vue
@@ -131,6 +131,13 @@ onMounted(async () => {
   acceptedSupervisionRequests.value = studentStore.acceptedSupervisionRequests[0];
 });
 
+onUnmounted(async() => {
+  if (toast.value.visible) {
+    await handleToastClosed();
+    window.location.reload(); // manually reload the page to ensure the dashboard state is updated
+  }
+});
+
 if (!supervisorStore.supervisors || supervisorStore.supervisors.length === 0) {
   const { data, error } = await useFetch(`/api/match/${ userStore.user?.id }`, {
     method: HttpMethods.GET,
@@ -150,10 +157,10 @@ const recommendedSupervisors = computed(() => {
       })
 });
 
-const handleSwipeRight = (supervisor: SupervisorData) => {
+const handleSwipeRight = async(supervisor: SupervisorData) => {
   // quickest solution in the wild west for the bug where spamming the slider wont send old requests
-  if (toast.value.visible) {
-    handleToastClosed();
+  if (toast.value.visible && modalInformation.value) {
+    await handleToastClosed();
   }
   removedSupervisor.value = supervisor;
   modalInformation.value = {
@@ -176,8 +183,8 @@ const handleSwipeRight = (supervisor: SupervisorData) => {
 };
 
 const handleSwipeLeft = async (supervisor: SupervisorData) => {
-  if (toast.value.visible) {
-    handleToastClosed();
+  if (toast.value.visible && modalInformation.value) {
+    await handleToastClosed();
   }
   removedSupervisor.value = supervisor;
   modalInformation.value = {
@@ -215,7 +222,6 @@ const handleToastUndoClick = async () => {
  * Its implemented this way to reduce the amount of request calls in case the user 'undoes' the action.
  */
 const handleToastClosed = () => {
-  console.log('closing toast for: ', modalInformation.value?.supervisor?.firstName);
   toast.value.visible = false;
   if (modalInformation.value?.supervisor) {
     handleActionConfirmation(modalInformation.value.supervisor);

--- a/Frontend/pages/supervisor/matching.vue
+++ b/Frontend/pages/supervisor/matching.vue
@@ -65,8 +65,6 @@ import EmptyPagePlaceholder from "~/components/Placeholder/EmptyPagePlaceholder.
 
 const supervisorStore = useSupervisorStore();
 const settingsStore = useSettingsStore();
-
-
 const swipeContainerRefs = ref<Record<string, InstanceType<typeof SwipeContainer> | null>>({})
 const modalInformation = ref<ConfirmationDialogData | null>(null)
 const currentActionRequest = ref<SupervisionRequestsData | null>(null);
@@ -75,6 +73,14 @@ const toast = ref({
   type: "success",
   message: "This is a toast message",
 });
+
+onUnmounted(async() => {
+  if (toast.value.visible) {
+    await handleToastClosed();
+    window.location.reload(); // manually reload the page to ensure the dashboard state is updated
+  }
+});
+
 
 if (!supervisorStore.supervisionRequests || !supervisorStore.supervisionRequests.length) {
   const { data, error } = await useFetch<SupervisionRequestsData[]>('/api/supervision-requests', {
@@ -98,10 +104,10 @@ const sortedRequests = computed(() => {
 });
 console.log('Supervisor Store:', sortedRequests.value);
 
-const handleSwipeRight = (request: SupervisionRequestsData) => {
+const handleSwipeRight = async (request: SupervisionRequestsData) => {
   // quickest solution in the wild west for the bug where spamming the slider wont send old requests
-  if (toast.value.visible) {
-    handleToastClosed();
+  if (toast.value.visible && modalInformation.value) {
+    await handleToastClosed();
   }
   currentActionRequest.value = request;
   modalInformation.value = {
@@ -123,10 +129,10 @@ const handleSwipeRight = (request: SupervisionRequestsData) => {
   }
 };
 
-const handleSwipeLeft = (request: SupervisionRequestsData) => {
+const handleSwipeLeft = async (request: SupervisionRequestsData) => {
   // quickest solution in the wild west for the bug where spamming the slider wont send old requests
-  if (toast.value.visible) {
-    handleToastClosed();
+  if (toast.value.visible && modalInformation.value) {
+    await handleToastClosed();
   }
   currentActionRequest.value = request;
   modalInformation.value = {


### PR DESCRIPTION
To test: 
- swipe on a supervisor and change pages instantly => should see the request (supervision or dismiss) reflected in the DB
- spam swipe and the application should handle each case without missing a single action