### PR TITLE
feat(backend): add endpoint to get pending requests count for specific user (SCRUM-245)

### DIFF
--- a/backend/src/common/exceptions/custom-exceptions/admin-supervision-request.exception.ts
+++ b/backend/src/common/exceptions/custom-exceptions/admin-supervision-request.exception.ts
@@ -1,0 +1,8 @@
+import { BadRequestException } from '@nestjs/common';
+
+export class AdminSupervisionRequestException extends BadRequestException {
+  constructor() {
+    super('Admin users do not send or receive supervision requests');
+    this.name = 'AdminSupervisionRequestException';
+  }
+}

--- a/backend/src/common/index.ts
+++ b/backend/src/common/index.ts
@@ -17,6 +17,7 @@ export * from './exceptions/custom-exceptions/request-already-exists.exception';
 export * from './exceptions/custom-exceptions/supervision-request-state-conflict.exception';
 export * from './exceptions/custom-exceptions/supervision-request-too-early.exception';
 export * from './exceptions/custom-exceptions/invalid-request-state-transition.exception';
+export * from './exceptions/custom-exceptions/admin-supervision-request.exception';
 
 // Validators
 export * from './validators/allowed-email-domains.validator';

--- a/backend/src/modules/requests/supervision/entities/pending-request-count.entity.ts
+++ b/backend/src/modules/requests/supervision/entities/pending-request-count.entity.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PendingRequestCountEntity {
+  @ApiProperty({
+    description: 'Number of pending supervision requests for the user',
+    example: 5,
+    minimum: 0,
+  })
+  pending_count: number;
+}

--- a/backend/src/modules/requests/supervision/supervision-requests.controller.spec.ts
+++ b/backend/src/modules/requests/supervision/supervision-requests.controller.spec.ts
@@ -420,35 +420,6 @@ describe('SupervisionRequestsController', () => {
       );
     });
 
-    it('should handle ParseUUIDPipe validation for invalid UUID', async () => {
-      // Arrange
-      const invalidUuid = 'invalid-uuid-format';
-      // Note: In real application, ParseUUIDPipe would throw before reaching the controller method
-      // This test documents the expected behavior but ParseUUIDPipe validation happens at the framework level
-
-      // Act & Assert
-      // The ParseUUIDPipe should prevent invalid UUIDs from reaching the controller method
-      // This test serves as documentation of the expected validation behavior
-      expect(controller.getPendingRequestCountForUser).toBeDefined();
-    });
-
-    it('should handle large request counts correctly', async () => {
-      // Arrange
-      const expectedResponse: PendingRequestCountEntity = { pending_count: 999 };
-      mockSupervisionRequestsService.countPendingRequestsForUser.mockResolvedValue(
-        expectedResponse,
-      );
-
-      // Act
-      const result = await controller.getPendingRequestCountForUser(SUPERVISOR_USER_UUID);
-
-      // Assert
-      expect(result).toEqual(expectedResponse);
-      expect(mockSupervisionRequestsService.countPendingRequestsForUser).toHaveBeenCalledWith(
-        SUPERVISOR_USER_UUID,
-      );
-    });
-
     it('should pass through any service errors', async () => {
       // Arrange
       const serviceError = new Error('Database connection failed');
@@ -461,28 +432,6 @@ describe('SupervisionRequestsController', () => {
       expect(mockSupervisionRequestsService.countPendingRequestsForUser).toHaveBeenCalledWith(
         STUDENT_USER_UUID,
       );
-    });
-
-    it('should work with different valid UUID formats', async () => {
-      // Arrange
-      const validUuids = [
-        '123e4567-e89b-12d3-a456-426614174000', // Standard format
-        'a1b2c3d4-e5f6-7890-1234-567890abcdef', // Different characters
-        '00000000-0000-0000-0000-000000000000', // All zeros
-      ];
-      const expectedResponse: PendingRequestCountEntity = { pending_count: 2 };
-      mockSupervisionRequestsService.countPendingRequestsForUser.mockResolvedValue(
-        expectedResponse,
-      );
-
-      // Act & Assert
-      for (const uuid of validUuids) {
-        const result = await controller.getPendingRequestCountForUser(uuid);
-        expect(result).toEqual(expectedResponse);
-        expect(mockSupervisionRequestsService.countPendingRequestsForUser).toHaveBeenCalledWith(
-          uuid,
-        );
-      }
     });
   });
 });

--- a/backend/src/modules/requests/supervision/supervision-requests.controller.ts
+++ b/backend/src/modules/requests/supervision/supervision-requests.controller.ts
@@ -6,6 +6,7 @@ import { UpdateSupervisionRequestDto } from './dto/update-supervision-request.dt
 import { SupervisionRequestQueryDto } from './dto/supervision-request-query.dto';
 import { SupervisionRequestEntity } from './entities/supervision-request.entity';
 import { SupervisionRequestWithUsersEntity } from './entities/supervision-request-with-users.entity';
+import { PendingRequestCountEntity } from './entities/pending-request-count.entity';
 import { CurrentUser } from '../../../common/decorators/current-user.decorator';
 import { RequestState, User } from '@prisma/client';
 
@@ -134,5 +135,37 @@ export class SupervisionRequestsController {
       updateDto.request_state,
       currentUser,
     );
+  }
+
+  @Get('pending-count/:userId')
+  @ApiOperation({
+    summary: 'Get pending supervision request count for a user',
+    description:
+      'Returns the count of pending supervision requests for a specific user. Requesting a student gets their outgoing requests, requesting a supervisor gets their incoming requests.',
+  })
+  @ApiParam({
+    name: 'userId',
+    description: 'ID of the user to get pending request count for',
+    type: String,
+    format: 'uuid',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Returns the count of pending supervision requests',
+    type: PendingRequestCountEntity,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request - Invalid UUID or admin user requested',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'User not found',
+  })
+  async getPendingRequestCountForUser(
+    @Param('userId', ParseUUIDPipe) userId: string,
+  ): Promise<PendingRequestCountEntity> {
+    return this.supervisionRequestsService.countPendingRequestsForUser(userId);
   }
 }

--- a/backend/src/modules/requests/supervision/supervision-requests.repository.ts
+++ b/backend/src/modules/requests/supervision/supervision-requests.repository.ts
@@ -92,6 +92,10 @@ export class SupervisionRequestsRepository {
 
   /**
    * Count supervision requests with filtering options
+   * @param request_state Optional request state filter
+   * @param student_id Optional student ID filter
+   * @param supervisor_id Optional supervisor ID filter
+   * @returns The total count of matching supervision requests
    */
   async countRequests(params: {
     request_state?: RequestState;

--- a/backend/src/modules/requests/supervision/supervision-requests.repository.ts
+++ b/backend/src/modules/requests/supervision/supervision-requests.repository.ts
@@ -91,6 +91,25 @@ export class SupervisionRequestsRepository {
   }
 
   /**
+   * Count supervision requests with filtering options
+   */
+  async countRequests(params: {
+    request_state?: RequestState;
+    student_id?: string;
+    supervisor_id?: string;
+  }): Promise<number> {
+    const { request_state, student_id, supervisor_id } = params;
+
+    return this.prisma.supervisionRequest.count({
+      where: {
+        ...(request_state && { request_state }),
+        ...(student_id && { student_id }),
+        ...(supervisor_id && { supervisor_id }),
+      },
+    });
+  }
+
+  /**
    * Create or find a student by email
    * @param email Student email
    * @param tx Optional transaction client

--- a/backend/src/modules/requests/supervision/supervision-requests.service.spec.ts
+++ b/backend/src/modules/requests/supervision/supervision-requests.service.spec.ts
@@ -780,26 +780,6 @@ describe('SupervisionRequestsService', () => {
       expect(mockRepository.countRequests).not.toHaveBeenCalled();
     });
 
-    it('should handle unknown role by returning 0', async () => {
-      // Arrange
-      const userWithUnknownRole = {
-        ...mockStudentUser,
-        role: 'UNKNOWN_ROLE' as Role, // Force unknown role for testing
-      };
-      mockUsersService.findUserById.mockResolvedValue(userWithUnknownRole);
-
-      // Act
-      const result = await service.countPendingRequestsForUser(userWithUnknownRole.id);
-
-      // Assert
-      expect(result).toEqual({ pending_count: 0 });
-      expect(mockUsersService.findUserById).toHaveBeenCalledWith(userWithUnknownRole.id);
-      // Should not call student or supervisor services for unknown role
-      expect(mockStudentsService.findStudentByUserId).not.toHaveBeenCalled();
-      expect(mockSupervisorsService.findSupervisorByUserId).not.toHaveBeenCalled();
-      expect(mockRepository.countRequests).not.toHaveBeenCalled();
-    });
-
     it('should handle errors from repository count method', async () => {
       // Arrange
       mockUsersService.findUserById.mockResolvedValue(mockStudentUser);

--- a/backend/src/modules/requests/supervision/supervision-requests.service.spec.ts
+++ b/backend/src/modules/requests/supervision/supervision-requests.service.spec.ts
@@ -15,6 +15,7 @@ import { SupervisorCapacityException } from '../../../common/exceptions/custom-e
 import { SelfSupervisionException } from '../../../common/exceptions/custom-exceptions/self-supervision.exception';
 import { SupervisorTargetException } from '../../../common/exceptions/custom-exceptions/supervisor-target.exception';
 import { MissingStudentEmailException } from '../../../common/exceptions/custom-exceptions/missing-student-email.exception';
+import { AdminSupervisionRequestException } from '../../../common/exceptions/custom-exceptions/admin-supervision-request.exception';
 
 describe('SupervisionRequestsService', () => {
   let service: SupervisionRequestsService;
@@ -25,6 +26,7 @@ describe('SupervisionRequestsService', () => {
     findRequestById: jest.fn(),
     createSupervisionRequest: jest.fn(),
     updateRequestState: jest.fn(),
+    countRequests: jest.fn(),
   };
 
   const mockStudentsService = {
@@ -661,6 +663,192 @@ describe('SupervisionRequestsService', () => {
       await expect(
         service.updateRequestState(REQUEST_UUID, RequestState.WITHDRAWN, mockStudentUser),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('countPendingRequestsForUser', () => {
+    it('should count pending requests for a student', async () => {
+      // Arrange
+      const expectedCount = 3;
+      mockUsersService.findUserById.mockResolvedValue(mockStudentUser);
+      mockStudentsService.findStudentByUserId.mockResolvedValue(mockStudent);
+      mockRepository.countRequests.mockResolvedValue(expectedCount);
+
+      // Act
+      const result = await service.countPendingRequestsForUser(mockStudentUser.id);
+
+      // Assert
+      expect(result).toEqual({ pending_count: expectedCount });
+      expect(mockUsersService.findUserById).toHaveBeenCalledWith(mockStudentUser.id);
+      expect(mockStudentsService.findStudentByUserId).toHaveBeenCalledWith(mockStudentUser.id);
+      expect(mockRepository.countRequests).toHaveBeenCalledWith({
+        student_id: mockStudent.id,
+        request_state: RequestState.PENDING,
+      });
+    });
+
+    it('should count pending requests for a supervisor', async () => {
+      // Arrange
+      const expectedCount = 5;
+      mockUsersService.findUserById.mockResolvedValue(mockSupervisorUser);
+      mockSupervisorsService.findSupervisorByUserId.mockResolvedValue(mockSupervisor);
+      mockRepository.countRequests.mockResolvedValue(expectedCount);
+
+      // Act
+      const result = await service.countPendingRequestsForUser(mockSupervisorUser.id);
+
+      // Assert
+      expect(result).toEqual({ pending_count: expectedCount });
+      expect(mockUsersService.findUserById).toHaveBeenCalledWith(mockSupervisorUser.id);
+      expect(mockSupervisorsService.findSupervisorByUserId).toHaveBeenCalledWith(
+        mockSupervisorUser.id,
+      );
+      expect(mockRepository.countRequests).toHaveBeenCalledWith({
+        supervisor_id: mockSupervisor.id,
+        request_state: RequestState.PENDING,
+      });
+    });
+
+    it('should return 0 for a student with no pending requests', async () => {
+      // Arrange
+      mockUsersService.findUserById.mockResolvedValue(mockStudentUser);
+      mockStudentsService.findStudentByUserId.mockResolvedValue(mockStudent);
+      mockRepository.countRequests.mockResolvedValue(0);
+
+      // Act
+      const result = await service.countPendingRequestsForUser(mockStudentUser.id);
+
+      // Assert
+      expect(result).toEqual({ pending_count: 0 });
+      expect(mockUsersService.findUserById).toHaveBeenCalledWith(mockStudentUser.id);
+      expect(mockStudentsService.findStudentByUserId).toHaveBeenCalledWith(mockStudentUser.id);
+      expect(mockRepository.countRequests).toHaveBeenCalledWith({
+        student_id: mockStudent.id,
+        request_state: RequestState.PENDING,
+      });
+    });
+
+    it('should return 0 for a supervisor with no pending requests', async () => {
+      // Arrange
+      mockUsersService.findUserById.mockResolvedValue(mockSupervisorUser);
+      mockSupervisorsService.findSupervisorByUserId.mockResolvedValue(mockSupervisor);
+      mockRepository.countRequests.mockResolvedValue(0);
+
+      // Act
+      const result = await service.countPendingRequestsForUser(mockSupervisorUser.id);
+
+      // Assert
+      expect(result).toEqual({ pending_count: 0 });
+      expect(mockUsersService.findUserById).toHaveBeenCalledWith(mockSupervisorUser.id);
+      expect(mockSupervisorsService.findSupervisorByUserId).toHaveBeenCalledWith(
+        mockSupervisorUser.id,
+      );
+      expect(mockRepository.countRequests).toHaveBeenCalledWith({
+        supervisor_id: mockSupervisor.id,
+        request_state: RequestState.PENDING,
+      });
+    });
+
+    it('should throw NotFoundException if user does not exist', async () => {
+      // Arrange
+      const nonExistentUserId = 'non-existent-user-id';
+      mockUsersService.findUserById.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.countPendingRequestsForUser(nonExistentUserId)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockUsersService.findUserById).toHaveBeenCalledWith(nonExistentUserId);
+      // Should not call other services if user doesn't exist
+      expect(mockStudentsService.findStudentByUserId).not.toHaveBeenCalled();
+      expect(mockSupervisorsService.findSupervisorByUserId).not.toHaveBeenCalled();
+      expect(mockRepository.countRequests).not.toHaveBeenCalled();
+    });
+
+    it('should throw AdminSupervisionRequestException if user is an admin', async () => {
+      // Arrange
+      mockUsersService.findUserById.mockResolvedValue(mockAdminUser);
+
+      // Act & Assert
+      await expect(service.countPendingRequestsForUser(mockAdminUser.id)).rejects.toThrow(
+        AdminSupervisionRequestException,
+      );
+      expect(mockUsersService.findUserById).toHaveBeenCalledWith(mockAdminUser.id);
+      // Should not call other services if user is admin
+      expect(mockStudentsService.findStudentByUserId).not.toHaveBeenCalled();
+      expect(mockSupervisorsService.findSupervisorByUserId).not.toHaveBeenCalled();
+      expect(mockRepository.countRequests).not.toHaveBeenCalled();
+    });
+
+    it('should handle unknown role by returning 0', async () => {
+      // Arrange
+      const userWithUnknownRole = {
+        ...mockStudentUser,
+        role: 'UNKNOWN_ROLE' as Role, // Force unknown role for testing
+      };
+      mockUsersService.findUserById.mockResolvedValue(userWithUnknownRole);
+
+      // Act
+      const result = await service.countPendingRequestsForUser(userWithUnknownRole.id);
+
+      // Assert
+      expect(result).toEqual({ pending_count: 0 });
+      expect(mockUsersService.findUserById).toHaveBeenCalledWith(userWithUnknownRole.id);
+      // Should not call student or supervisor services for unknown role
+      expect(mockStudentsService.findStudentByUserId).not.toHaveBeenCalled();
+      expect(mockSupervisorsService.findSupervisorByUserId).not.toHaveBeenCalled();
+      expect(mockRepository.countRequests).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors from repository count method', async () => {
+      // Arrange
+      mockUsersService.findUserById.mockResolvedValue(mockStudentUser);
+      mockStudentsService.findStudentByUserId.mockResolvedValue(mockStudent);
+      const repositoryError = new Error('Database connection error');
+      mockRepository.countRequests.mockRejectedValue(repositoryError);
+
+      // Act & Assert
+      await expect(service.countPendingRequestsForUser(mockStudentUser.id)).rejects.toThrow(
+        'Database connection error',
+      );
+      expect(mockUsersService.findUserById).toHaveBeenCalledWith(mockStudentUser.id);
+      expect(mockStudentsService.findStudentByUserId).toHaveBeenCalledWith(mockStudentUser.id);
+      expect(mockRepository.countRequests).toHaveBeenCalledWith({
+        student_id: mockStudent.id,
+        request_state: RequestState.PENDING,
+      });
+    });
+
+    it('should handle errors from students service', async () => {
+      // Arrange
+      mockUsersService.findUserById.mockResolvedValue(mockStudentUser);
+      const studentsServiceError = new NotFoundException('Student profile not found');
+      mockStudentsService.findStudentByUserId.mockRejectedValue(studentsServiceError);
+
+      // Act & Assert
+      await expect(service.countPendingRequestsForUser(mockStudentUser.id)).rejects.toThrow(
+        'Student profile not found',
+      );
+      expect(mockUsersService.findUserById).toHaveBeenCalledWith(mockStudentUser.id);
+      expect(mockStudentsService.findStudentByUserId).toHaveBeenCalledWith(mockStudentUser.id);
+      expect(mockRepository.countRequests).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors from supervisors service', async () => {
+      // Arrange
+      mockUsersService.findUserById.mockResolvedValue(mockSupervisorUser);
+      const supervisorsServiceError = new NotFoundException('Supervisor profile not found');
+      mockSupervisorsService.findSupervisorByUserId.mockRejectedValue(supervisorsServiceError);
+
+      // Act & Assert
+      await expect(service.countPendingRequestsForUser(mockSupervisorUser.id)).rejects.toThrow(
+        'Supervisor profile not found',
+      );
+      expect(mockUsersService.findUserById).toHaveBeenCalledWith(mockSupervisorUser.id);
+      expect(mockSupervisorsService.findSupervisorByUserId).toHaveBeenCalledWith(
+        mockSupervisorUser.id,
+      );
+      expect(mockRepository.countRequests).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
### **What?**
Added `GET /supervision-requests/pending-count/:userId` endpoint that returns the count of pending supervision requests for any user. Accessible by all user roles.

### **Why?**
Enables frontend to display pending request counts on supervisor discovery pages and user profile pages without requiring full request data retrieval.

### **How?**
- **Controller**: New `getPendingRequestCountForUser` endpoint with UUID validation via `ParseUUIDPipe`
- **Validation**: Admin users blocked with `AdminSupervisionRequestException`, 404 for non-existent users
- **Response**: Simple `{ pending_count: number }` format via new `PendingRequestCountEntity`

### **API Example**
```
GET /supervision-requests/pending-count/123e4567-e89b-12d3-a456-426614174000
→ { "pending_count": 5 }
```