### PR TITLE
Scrum 278 frontend fix request acceptances rejections not sending until toast disapperas supervisor matching page

### DIFF
--- a/Frontend/components/SupervisorStudentList/SupervisorStudentList.vue
+++ b/Frontend/components/SupervisorStudentList/SupervisorStudentList.vue
@@ -164,7 +164,7 @@ watch(
         <!-- Student List -->
         <NuxtLink
             v-for="student in students" :key="student.id"
-            :to="`/profiles/${student.id}`"
+            :to="!isEditing ? `/profiles/${student.id}` : ''"
             actions
             comment-more
         >

--- a/Frontend/components/TagSelector/TagSelector.vue
+++ b/Frontend/components/TagSelector/TagSelector.vue
@@ -26,7 +26,6 @@ const selectedTags = ref([ ...props.initialSelected ]);
 
 // Watch for changes in initialSelected prop and update the selectedTags accordingly
 watch(() => props.initialSelected, (newValue) => {
-  console.log("initialSelected changed:", newValue);
   selectedTags.value = [ ...newValue ];
   emit('update:selectedTags', selectedTags.value);
 }, { deep: true });

--- a/Frontend/pages/onboarding/supervisor.vue
+++ b/Frontend/pages/onboarding/supervisor.vue
@@ -95,7 +95,6 @@ onMounted(async () => {
         await registrationStore.fetchRegistrationStatus(user.value.primaryEmailAddress?.emailAddress)
     }
   if (registrationStore.status?.is_registered) {
-    console.log('User is already registered');
     DbTags.value = (await getTags()) as tagData[];
     return
   }
@@ -130,11 +129,11 @@ const handleSubmit = async () => {
   if (!userStore.user) {
     await userStore.refetchCurrentUser();
   }
-  addUserTag({
+  await addUserTag({
     id: userStore.user?.id,
     tags: tags.value as tagData[],
   });
-  navigateTo('/supervisor/dashboard');
+  return navigateTo('/supervisor/dashboard');
 };
 
 

--- a/Frontend/pages/onboarding/supervisor.vue
+++ b/Frontend/pages/onboarding/supervisor.vue
@@ -106,7 +106,7 @@ onMounted(async () => {
           ?.emailAddress,
     } as UserCreateData)) as UserData;
     userStore.setUser(res);
-
+    DbTags.value = (await getTags()) as tagData[];
   } catch (error) {
     console.error('Error fetching data:', error);
   }

--- a/Frontend/pages/student/dashboard.vue
+++ b/Frontend/pages/student/dashboard.vue
@@ -182,19 +182,19 @@ const studentStore = useStudentStore();
 
 const isLoading = ref(true);
 
-const dashboardState = studentStore.dashboardState;
-const supervisionRequestsSentByCurrentStudent = studentStore.supervisionRequestsSentByCurrentStudent;
-const acceptedSupervisionRequests = studentStore.acceptedSupervisionRequests;
+const dashboardState = computed(() => studentStore.dashboardState);
+const supervisionRequestsSentByCurrentStudent = computed(() => studentStore.supervisionRequestsSentByCurrentStudent);
+const acceptedSupervisionRequests = computed(() => studentStore.acceptedSupervisionRequests);
 
 // if for some reason the user has more than one accepted supervision request, we will show a warning
 const warning = computed(() => {
-  if (acceptedSupervisionRequests.length > 1) {
-    const namesOfAcceptedSupervisors = acceptedSupervisionRequests.map(
+  if (acceptedSupervisionRequests.value.length > 1) {
+    const namesOfAcceptedSupervisors = acceptedSupervisionRequests.value.map(
         (request) =>
             `${ request.supervisor.user.first_name } ${ request.supervisor.user.last_name }`
     );
     return t("dashboard.student.multipleAcceptedWarning", {
-      count: acceptedSupervisionRequests.length,
+      count: acceptedSupervisionRequests.value.length,
       supervisors: namesOfAcceptedSupervisors.join(", "),
     });
   }
@@ -202,8 +202,8 @@ const warning = computed(() => {
 });
 
 const warningModalId = computed(() => {
-  if (acceptedSupervisionRequests.length > 0) {
-    return `confirmation-modal-${ acceptedSupervisionRequests[0].id }`;
+  if (acceptedSupervisionRequests.value.length > 0) {
+    return `confirmation-modal-${ acceptedSupervisionRequests.value[0].id }`;
   }
   return "confirmation-modal-warning";
 });
@@ -217,7 +217,7 @@ onMounted(async () => {
             studentStore.fetchSupervisionRequests(),
             userStore.user ? Promise.resolve() : userStore.refetchCurrentUser()
         ]);
-        if (acceptedSupervisionRequests.length > 1) {
+        if (acceptedSupervisionRequests.value.length > 1) {
             const modal = document.getElementById(
                 warningModalId.value
             ) as HTMLDialogElement;
@@ -242,7 +242,7 @@ onMounted(async () => {
 });
 
 watch(
-    () => acceptedSupervisionRequests.length,
+    () => acceptedSupervisionRequests.value.length,
     (newLength) => {
       if (newLength > 1) {
         nextTick(() => {

--- a/Frontend/pages/student/dashboard.vue
+++ b/Frontend/pages/student/dashboard.vue
@@ -183,7 +183,11 @@ const studentStore = useStudentStore();
 const isLoading = ref(true);
 
 const dashboardState = computed(() => studentStore.dashboardState);
-const supervisionRequestsSentByCurrentStudent = computed(() => studentStore.supervisionRequestsSentByCurrentStudent);
+const supervisionRequestsSentByCurrentStudent = computed(() => 
+  studentStore.supervisionRequestsSentByCurrentStudent.filter(
+    (request) => request.request_state === supervisionRequestStatus.PENDING
+  )
+);
 const acceptedSupervisionRequests = computed(() => studentStore.acceptedSupervisionRequests);
 
 // if for some reason the user has more than one accepted supervision request, we will show a warning

--- a/Frontend/pages/student/matching.vue
+++ b/Frontend/pages/student/matching.vue
@@ -134,7 +134,6 @@ onMounted(async () => {
 onUnmounted(async () => {
   if (toast.value.visible) {
     await handleToastClosed();
-    window.location.reload(); // manually reload the page to ensure the dashboard state is updated
   }
 });
 

--- a/Frontend/pages/supervisor/matching.vue
+++ b/Frontend/pages/supervisor/matching.vue
@@ -70,7 +70,6 @@ const toast = ref({
 onUnmounted(async () => {
   if (toast.value.visible) {
     await handleToastClosed();
-    window.location.reload(); // manually reload the page to ensure the dashboard state is updated
   }
 });
 


### PR DESCRIPTION
Things addressed:
- page refresh when navigating out of matching page before toast is closed
- bug preventing tags to load if user isnt registered
- bug preventing navigation to dashboard after completing supervisor onboarding
- bug leading to student profile after deleting them from "currently supervising" page
- bug student dashboard showing the incorrect state on hard refresh (made the state reactive as a solution)
- bug student dashboard showing requests that are not currenly pending