### PR TITLE
feat(backend): implement comprehensive user deletion with authorization and safety checks (SCRUM-304)

### DIFF
--- a/backend/src/common/exceptions/custom-exceptions/last-admin-delete.exception.ts
+++ b/backend/src/common/exceptions/custom-exceptions/last-admin-delete.exception.ts
@@ -1,0 +1,8 @@
+import { ForbiddenException } from '@nestjs/common';
+
+export class LastAdminDeleteException extends ForbiddenException {
+  constructor() {
+    super('Cannot delete the last admin in the system');
+    this.name = 'LastAdminDeleteException';
+  }
+}

--- a/backend/src/common/exceptions/custom-exceptions/user-delete-forbidden.exception.ts
+++ b/backend/src/common/exceptions/custom-exceptions/user-delete-forbidden.exception.ts
@@ -1,0 +1,8 @@
+import { ForbiddenException } from '@nestjs/common';
+
+export class UserDeleteForbiddenException extends ForbiddenException {
+  constructor() {
+    super('You can only delete your own account');
+    this.name = 'UserDeleteForbiddenException';
+  }
+}

--- a/backend/src/modules/users/dto/delete-user-success.dto.ts
+++ b/backend/src/modules/users/dto/delete-user-success.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DeleteUserSuccessDto {
+  @ApiProperty({
+    description: 'Indicates if the operation was successful',
+    example: true,
+  })
+  success: boolean;
+
+  @ApiProperty({
+    description: 'Success message with user email',
+    example: 'User john.doe@fhstp.ac.at has been deleted successfully',
+  })
+  message: string;
+}

--- a/backend/src/modules/users/types/user-operations.types.ts
+++ b/backend/src/modules/users/types/user-operations.types.ts
@@ -1,0 +1,27 @@
+import { Role } from '@prisma/client';
+
+/**
+ * Type definition for user deletion operation parameters
+ *
+ * Provides type safety for the complex user deletion process
+ * that involves multiple related entities and database operations.
+ */
+export interface DeleteUserOperation {
+  userId: string;
+  userEmail: string;
+  userRole: Role;
+  studentId?: string;
+  supervisorId?: string;
+}
+
+/**
+ * Type definition for user deletion operation results
+ *
+ * Contains statistics about what was deleted/modified during
+ * the user deletion process for logging and audit purposes.
+ */
+export interface DeleteUserResult {
+  deletedTagsCount: number;
+  deletedBlocksCount: number;
+  profileUpdated: boolean;
+}


### PR DESCRIPTION
### Changes
- Added authorization logic (users delete own accounts, admins delete any, last admin protection)
- Implemented transaction-based soft deletion preserving email/role/clerk_id while clearing PII
- Added role-specific profile cleanup (student thesis_description, supervisor bio/spots)
- Included enhanced logging with deletion statistics
- Replaced hardcoded constants with configurable limits (User search limit)
- Complete rewrite with comprehensive test coverage for deletion scenarios